### PR TITLE
HFR identity guard: refuse writes under the wrong account (#32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Les structs d'entrée MCP portent des tags `jsonschema` : le SDK en dérive le s
 - Identifiants HFR : variables d'env `HFR_LOGIN` / `HFR_PASSWD` (prioritaires), sinon `./hfr.conf` puis `~/.config/hfr/config` (format `login=` / `passwd=`).
 - MCP : login *lazy* (connexion au premier appel d'outil), session conservée en mémoire pour la durée du process.
 - Les outils d'écriture (`hfr_reply`, `hfr_edit`, `hfr_mp`, `hfr_create_topic`, `hfr_quote`) exigent l'authentification ; `hfr_read`, `hfr_topics` et `hfr_cats` fonctionnent en anonyme.
+- **Garde-fou d'identité** (#32) : les écritures sont refusées par défaut tant qu'aucun compte attendu n'est déclaré (`HFR_EXPECT_LOGIN` / `expect_login=` côté serveur, `expect` MCP ou `--pseudo` CLI par appel). Comparaison par pseudo (casse ignorée) ou userId ; syntaxe typée `pseudo:` / `id:`. Opt-out historique : `HFR_ALLOW_UNGUARDED_WRITES=1`. `hfr_whoami` / `hfr whoami` expose le compte actif. L'autorité = le cookie `md_user` de session relu juste avant chaque POST.
 
 ## Conventions de contenu HFR
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.2.0] - 2026-06-14
+
+### Features
+- Identity guard (#32): writes (`hfr_reply`, `hfr_edit`, `hfr_create_topic`, `hfr_mp` / `reply`, `edit`, `new`, `mp`) are refused when the logged-in account doesn't match the expected one. Fail-closed by default.
+- Expected account declared via `HFR_EXPECT_LOGIN` (env) / `expect_login=` (config) server-side, and per-call via the `expect` MCP parameter or the `--pseudo` CLI flag. Typed syntax: `pseudo:<name>`, `id:<n>`, bare numeric → userId.
+- `HFR_ALLOW_UNGUARDED_WRITES=1` opt-out for the historical (unguarded) behaviour.
+- New `hfr_whoami` MCP tool / `hfr whoami` CLI command: report the active account (pseudo + userId) and the expected account.
+- Write results now report the account effectively used.
+
+### Fixes
+- Login hardening: client state is mutated only on full success — a failed `hash_check`/profile fetch no longer leaves a half-authenticated client.
+
 ## [1.1.0] - 2026-04-11
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Lire des topics, poster des reponses, editer des messages, citer, envoyer des MP
 | Lire un topic | `hfr_read` | `hfr read <cat> <post> [page]` |
 | Lire en mode print | `hfr_read` (print=true) | `hfr print <cat> <post> [page]` |
 | Lister les topics d'une categorie | `hfr_topics` | `hfr topics <cat> [subcat]` |
+| Lister les categories | `hfr_cats` | `hfr cats [cat]` |
 | Poster une reponse | `hfr_reply` | `hfr reply <cat> <post> <content>` |
+| Creer un topic | `hfr_create_topic` | `hfr new <cat> <subcat> <subject> <content>` |
 | Editer un post | `hfr_edit` | `hfr edit <cat> <post> <numreponse> <content>` |
 | Citer un message | `hfr_quote` | `hfr quote <cat> <post> <numreponse>` |
 | Multiquote | `hfr_quote` (numreponses) | `hfr quote <cat> <post> <n1> <n2> ...` |
 | Envoyer un MP | `hfr_mp` | `hfr mp <dest> <subject> <content>` |
+| Compte actif | `hfr_whoami` | `hfr whoami` |
 | Version | — | `hfr version` / `hfr-mcp --version` |
 
 Le contenu utilise le BBCode HFR (`[b]`, `[url=]`, `[quotemsg=...]`, smileys `:o`, `[:pseudo]`, etc.).
@@ -66,6 +69,17 @@ passwd=motdepasse
 
 Les variables d'environnement `HFR_LOGIN` / `HFR_PASSWD` prennent le dessus sur le fichier. Les permissions du fichier sont verifiees au demarrage : un warning s'affiche s'il est lisible par d'autres utilisateurs.
 
+### Garde-fou d'identite
+
+Pour eviter de poster sous le mauvais compte, les ecritures (`hfr_reply`, `hfr_edit`, `hfr_create_topic`, `hfr_mp`) sont **refusees par defaut** tant qu'aucun compte attendu n'est declare. On declare le compte attendu :
+
+- cote serveur : `HFR_EXPECT_LOGIN` (env) ou `expect_login=` (fichier de config) ;
+- par appel : parametre `expect` (MCP) ou flag `--pseudo <login>` (CLI).
+
+La comparaison se fait sur le pseudo (insensible a la casse) **ou** le userId. Syntaxe typee : `pseudo:<nom>`, `id:<n>` ; un nombre nu vise le userId. Si la session connectee ne correspond pas, l'ecriture est refusee **avant** tout envoi.
+
+Pour retrouver le comportement historique (sans garde-fou), exporter `HFR_ALLOW_UNGUARDED_WRITES=1`. `hfr_whoami` / `hfr whoami` affiche le compte actif et le compte attendu.
+
 ## Utilisation CLI
 
 ```bash
@@ -106,9 +120,15 @@ hfr edit 13 120036 74497677 "contenu modifie"
 
 # Envoyer un MP
 hfr mp pseudo "Sujet" "Corps du message"
+
+# Verifier le compte actif
+hfr whoami
+
+# Ecrire en exigeant un compte precis (refus si la session differe)
+hfr --pseudo xatelitte reply 13 120036 "Hello"
 ```
 
-Les commandes d'ecriture (reply, edit, quote, mp) exigent l'authentification (automatique). `read`, `print` et `topics` fonctionnent en anonyme par defaut, `--auth` pour se connecter.
+Les commandes d'ecriture (`new`, `reply`, `edit`, `mp`) et `quote`/`whoami` exigent l'authentification (automatique). `read`, `print`, `topics` et `cats` fonctionnent en anonyme par defaut, `--auth` pour se connecter. Les ecritures appliquent le garde-fou d'identite (voir [Garde-fou d'identite](#garde-fou-didentite)).
 
 ## Outils MCP
 
@@ -116,10 +136,13 @@ Les commandes d'ecriture (reply, edit, quote, mp) exigent l'authentification (au
 |-------|-------------|
 | `hfr_read` | Lire un topic. `page=0` pour la derniere page, `page_from`/`page_to` pour du batch concurrent, `print=true` pour le mode impression, `last=N` pour les N derniers posts |
 | `hfr_topics` | Lister les topics d'une categorie/sous-categorie avec pagination |
-| `hfr_reply` | Poster une reponse (BBCode) |
-| `hfr_edit` | Editer un post existant (detecte le first post, preserve le sujet) |
+| `hfr_cats` | Lister les categories (et les sous-categories d'une categorie) |
+| `hfr_reply` | Poster une reponse (BBCode). Param `expect` pour le garde-fou d'identite |
+| `hfr_create_topic` | Creer un topic. Param `expect` pour le garde-fou d'identite |
+| `hfr_edit` | Editer un post existant (detecte le first post, preserve le sujet). Param `expect` |
 | `hfr_quote` | Citer un ou plusieurs messages (`numreponse` ou `numreponses[]`) |
-| `hfr_mp` | Envoyer un message prive |
+| `hfr_mp` | Envoyer un message prive. Param `expect` pour le garde-fou d'identite |
+| `hfr_whoami` | Afficher le compte actif (pseudo + userId) et le compte attendu |
 
 ## Optimisation tokens
 

--- a/cmd/hfr-mcp/main.go
+++ b/cmd/hfr-mcp/main.go
@@ -28,6 +28,8 @@ func main() {
 
 	// Create HFR client (login will happen lazily on first tool call)
 	client := hfr.NewClient()
+	client.SetExpectedLogin(cfg.ExpectLogin)
+	client.SetAllowUnguarded(cfg.AllowUnguarded)
 
 	// Lazy login: only login once, on first tool call
 	var loginOnce sync.Once

--- a/cmd/hfr/main.go
+++ b/cmd/hfr/main.go
@@ -113,7 +113,15 @@ loop:
 		if err != nil {
 			die("whoami failed: %v", err)
 		}
-		fmt.Printf("Connecté : %s (userId %s)\n", id.Pseudo, id.UserID)
+		expect := client.ExpectedLogin()
+		if expect == "" {
+			expect = "(non défini)"
+		}
+		guard := "inactive"
+		if client.GuardActive() {
+			guard = "active"
+		}
+		fmt.Printf("Connecté : %s (userId %s)\nCompte attendu : %s\nGarde : %s\n", id.Pseudo, id.UserID, expect, guard)
 	default:
 		die("unknown command: %s\n\n%s", cmd, usage)
 	}

--- a/cmd/hfr/main.go
+++ b/cmd/hfr/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ForumHFR/hfr-mcp/internal/hfr"
 )
 
-const usage = `Usage: hfr [--auth] <command> [args...]
+const usage = `Usage: hfr [--auth] [--pseudo <login>] <command> [args...]
 
 Commands:
   cats     [cat]                               List categories (or subcats for a cat)
@@ -23,13 +23,18 @@ Commands:
   edit     <cat> <post> <numreponse> <content|--file path>  Edit a post
   quote    <cat> <post> <numreponse>          Get quote BBCode
   mp       <dest> <subject> <content>         Send a private message
+  whoami                                      Show the currently logged-in account
   version                                     Show version
 
 Options:
-  --auth    Login before executing. Required for new, reply, edit, quote, mp.
+  --auth             Login before executing. Required for new, reply, edit, quote, mp, whoami.
+  --pseudo <login>   Refuse to write if the logged-in account differs from <login>.
 
-Config: ./hfr.conf or ~/.config/hfr/config (login=, passwd=)
-Env vars HFR_LOGIN/HFR_PASSWD override config file.`
+Writes are refused unless an expected account is set (--pseudo / expect_login= /
+HFR_EXPECT_LOGIN), or HFR_ALLOW_UNGUARDED_WRITES=1 is exported to opt out.
+
+Config: ./hfr.conf or ~/.config/hfr/config (login=, passwd=, expect_login=)
+Env vars HFR_LOGIN/HFR_PASSWD/HFR_EXPECT_LOGIN override config file.`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -38,9 +43,19 @@ func main() {
 
 	args := os.Args[1:]
 	auth := false
-	if args[0] == "--auth" {
-		auth = true
-		args = args[1:]
+	pseudo := ""
+loop:
+	for len(args) > 0 {
+		switch {
+		case args[0] == "--auth":
+			auth = true
+			args = args[1:]
+		case args[0] == "--pseudo" && len(args) > 1:
+			pseudo = args[1]
+			args = args[2:]
+		default:
+			break loop
+		}
 	}
 
 	if len(args) < 1 {
@@ -70,6 +85,8 @@ func main() {
 		if err := client.Login(cfg.Login, cfg.Passwd); err != nil {
 			die("login failed: %v", err)
 		}
+		client.SetExpectedLogin(cfg.ExpectLogin)
+		client.SetAllowUnguarded(cfg.AllowUnguarded)
 	}
 
 	switch cmd {
@@ -82,15 +99,21 @@ func main() {
 	case "print":
 		cmdPrint(client, args)
 	case "new":
-		cmdNewTopic(client, args)
+		cmdNewTopic(client, args, pseudo)
 	case "reply":
-		cmdReply(client, args)
+		cmdReply(client, args, pseudo)
 	case "edit":
-		cmdEdit(client, args)
+		cmdEdit(client, args, pseudo)
 	case "quote":
 		cmdQuote(client, args)
 	case "mp":
-		cmdMP(client, args)
+		cmdMP(client, args, pseudo)
+	case "whoami":
+		id, err := client.Whoami()
+		if err != nil {
+			die("whoami failed: %v", err)
+		}
+		fmt.Printf("Connecté : %s (userId %s)\n", id.Pseudo, id.UserID)
 	default:
 		die("unknown command: %s\n\n%s", cmd, usage)
 	}
@@ -244,7 +267,7 @@ func parsePageRef(s string) int {
 	return mustInt(s, "page")
 }
 
-func cmdNewTopic(client *hfr.Client, args []string) {
+func cmdNewTopic(client *hfr.Client, args []string, expect string) {
 	if len(args) < 4 {
 		die("usage: hfr new <cat> <subcat> <subject> <content|--file path>")
 	}
@@ -252,28 +275,28 @@ func cmdNewTopic(client *hfr.Client, args []string) {
 	subcat := mustInt(args[1], "subcat")
 	subject := args[2]
 	content := readContent(args[3:])
-
-	if err := client.CreateTopic(cat, subcat, subject, content); err != nil {
+	id, err := client.CreateTopic(cat, subcat, subject, content, expect)
+	if err != nil {
 		die("create topic failed: %v", err)
 	}
-	fmt.Println("Topic created.")
+	fmt.Printf("Topic created (as %s / userId %s).\n", id.Pseudo, id.UserID)
 }
 
-func cmdReply(client *hfr.Client, args []string) {
+func cmdReply(client *hfr.Client, args []string, expect string) {
 	if len(args) < 3 {
 		die("usage: hfr reply <cat> <post> <content|--file path>")
 	}
 	cat := mustInt(args[0], "cat")
 	post := mustInt(args[1], "post")
 	content := readContent(args[2:])
-
-	if err := client.Reply(cat, post, content); err != nil {
+	id, err := client.Reply(cat, post, content, expect)
+	if err != nil {
 		die("reply failed: %v", err)
 	}
-	fmt.Println("Reply posted.")
+	fmt.Printf("Reply posted (as %s / userId %s).\n", id.Pseudo, id.UserID)
 }
 
-func cmdEdit(client *hfr.Client, args []string) {
+func cmdEdit(client *hfr.Client, args []string, expect string) {
 	if len(args) < 4 {
 		die("usage: hfr edit <cat> <post> <numreponse> <content|--file path>")
 	}
@@ -281,11 +304,11 @@ func cmdEdit(client *hfr.Client, args []string) {
 	post := mustInt(args[1], "post")
 	numreponse := mustInt(args[2], "numreponse")
 	content := readContent(args[3:])
-
-	if err := client.Edit(cat, post, numreponse, content); err != nil {
+	id, err := client.Edit(cat, post, numreponse, content, expect)
+	if err != nil {
 		die("edit failed: %v", err)
 	}
-	fmt.Println("Post edited.")
+	fmt.Printf("Post edited (as %s / userId %s).\n", id.Pseudo, id.UserID)
 }
 
 func readContent(args []string) string {
@@ -330,18 +353,18 @@ func cmdQuote(client *hfr.Client, args []string) {
 	fmt.Println(bbcode)
 }
 
-func cmdMP(client *hfr.Client, args []string) {
+func cmdMP(client *hfr.Client, args []string, expect string) {
 	if len(args) < 3 {
 		die("usage: hfr mp <dest> <subject> <content>")
 	}
 	dest := args[0]
 	subject := args[1]
 	content := strings.Join(args[2:], " ")
-
-	if err := client.SendMP(dest, subject, content); err != nil {
+	id, err := client.SendMP(dest, subject, content, expect)
+	if err != nil {
 		die("mp failed: %v", err)
 	}
-	fmt.Println("MP sent.")
+	fmt.Printf("MP sent (as %s / userId %s).\n", id.Pseudo, id.UserID)
 }
 
 func mustInt(s, name string) int {

--- a/docs/superpowers/plans/2026-06-14-hfr-identity-guard.md
+++ b/docs/superpowers/plans/2026-06-14-hfr-identity-guard.md
@@ -1,0 +1,1173 @@
+# HFR Identity Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refuse HFR writes when the logged-in account doesn't match the expected account, and expose the active account, so messages never go out under the wrong identity.
+
+**Architecture:** All logic lives in the `hfr.Client`. Writes go through one atomic path (`authenticatedPost`) that resolves the *current* identity from the `md_user` cookie (the real POST authority), checks it against the expected account (server `HFR_EXPECT_LOGIN` and per-call `expect`), and only then POSTs. Fail-closed by default unless `HFR_ALLOW_UNGUARDED_WRITES=1`. CLI and MCP only feed constraints and format the returned `Identity`.
+
+**Tech Stack:** Go 1.25, `goquery`, `modelcontextprotocol/go-sdk`, `net/http/httptest` for tests.
+
+**Spec:** `/work/xaat/hfr-mcp/docs/superpowers/specs/2026-06-14-hfr-identity-guard-design.md`
+
+**Working branch:** create `feat/32-identity-guard` off `dev` before Task 1 (`git switch -c feat/32-identity-guard`). Commit identity is the repo-local `xat <xat@azora.fr>` (already configured). Each commit message ends with the `Co-Authored-By` trailer.
+
+**Validate-before-push (per AGENTS.md):** `go vet ./...`, `golangci-lint run`, `go build ./...`, `go test ./...`.
+
+---
+
+## Task 1: Identity value type + matching logic (pure)
+
+**Files:**
+- Create: `internal/hfr/identity.go`
+- Modify: `internal/hfr/errors.go`
+- Test: `internal/hfr/identity_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/hfr/identity_test.go`:
+
+```go
+package hfr
+
+import "testing"
+
+func TestIdentityMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      Identity
+		want    string
+		ok      bool
+		wantErr bool
+	}{
+		{"pseudo exact", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "xatelitte", true, false},
+		{"pseudo case+space", Identity{Pseudo: "xatelitte"}, "  XaTeLitte ", true, false},
+		{"pseudo mismatch", Identity{Pseudo: "XaTriX"}, "xatelitte", false, false},
+		{"pseudo prefix", Identity{Pseudo: "xatelitte"}, "pseudo:xatelitte", true, false},
+		{"id prefix match", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "id:1214571", true, false},
+		{"id prefix mismatch", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "id:54596", false, false},
+		{"bare numeric -> userId", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "1214571", true, false},
+		{"numeric pseudo via prefix", Identity{Pseudo: "1234"}, "pseudo:1234", true, false},
+		{"id wanted but unresolved", Identity{Pseudo: "xatelitte", UserID: ""}, "id:1214571", false, true},
+		{"zero is a real constraint", Identity{Pseudo: "x", UserID: "5"}, "0", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := identityMatches(tc.id, tc.want)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/hfr/ -run TestIdentityMatches -v`
+Expected: FAIL — `undefined: Identity` / `undefined: identityMatches`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/hfr/identity.go`:
+
+```go
+package hfr
+
+import "strings"
+
+// Identity is the account currently behind the session.
+type Identity struct {
+	Pseudo        string
+	UserID        string
+	Authenticated bool
+}
+
+// normalize folds case and trims surrounding space for pseudo comparison.
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseExpect splits a typed constraint.
+// "id:123" -> (true,"123"); "pseudo:xat" -> (false,"xat");
+// bare all-digits -> (true, digits); otherwise (false, trimmed).
+func parseExpect(want string) (isID bool, value string) {
+	w := strings.TrimSpace(want)
+	switch {
+	case strings.HasPrefix(w, "id:"):
+		return true, strings.TrimSpace(strings.TrimPrefix(w, "id:"))
+	case strings.HasPrefix(w, "pseudo:"):
+		return false, strings.TrimSpace(strings.TrimPrefix(w, "pseudo:"))
+	default:
+		if isAllDigits(w) {
+			return true, w
+		}
+		return false, w
+	}
+}
+
+// identityMatches reports whether id satisfies the constraint want.
+// It errors if want targets a userId the session could not resolve.
+func identityMatches(id Identity, want string) (bool, error) {
+	isID, val := parseExpect(want)
+	if isID {
+		if id.UserID == "" {
+			return false, &HfrError{Code: "identity", Message: "expected account is a userId but the session userId could not be resolved"}
+		}
+		return val == id.UserID, nil
+	}
+	return normalize(val) == normalize(id.Pseudo), nil
+}
+```
+
+Add to `internal/hfr/errors.go` inside the `var (...)` block:
+
+```go
+	ErrNoExpectedAccount = &HfrError{Code: "identity", Message: "write refused: no expected account configured (set HFR_EXPECT_LOGIN / --pseudo, or HFR_ALLOW_UNGUARDED_WRITES=1)"}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/hfr/ -run TestIdentityMatches -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hfr/identity.go internal/hfr/identity_test.go internal/hfr/errors.go
+git commit -m "feat(hfr): identity type + typed expect matching (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Guard fields on Client + checkIdentity (fail-closed)
+
+**Files:**
+- Modify: `internal/hfr/client.go` (struct + setters)
+- Modify: `internal/hfr/identity.go` (add `checkIdentity`)
+- Test: `internal/hfr/identity_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/hfr/identity_test.go`:
+
+```go
+func TestCheckIdentity(t *testing.T) {
+	id := Identity{Pseudo: "xatelitte", UserID: "1214571", Authenticated: true}
+
+	t.Run("no constraint, fail-closed", func(t *testing.T) {
+		c := &Client{}
+		if err := c.checkIdentity(id, ""); err != ErrNoExpectedAccount {
+			t.Fatalf("got %v, want ErrNoExpectedAccount", err)
+		}
+	})
+	t.Run("no constraint, opt-out allows", func(t *testing.T) {
+		c := &Client{allowUnguarded: true}
+		if err := c.checkIdentity(id, ""); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+	t.Run("server constraint match", func(t *testing.T) {
+		c := &Client{expectedLogin: "xatelitte"}
+		if err := c.checkIdentity(id, ""); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+	t.Run("server constraint mismatch", func(t *testing.T) {
+		c := &Client{expectedLogin: "XaTriX"}
+		err := c.checkIdentity(id, "")
+		if he, ok := err.(*HfrError); !ok || he.Code != "identity" {
+			t.Fatalf("got %v, want identity error", err)
+		}
+	})
+	t.Run("call constraint mismatch beats matching server", func(t *testing.T) {
+		c := &Client{expectedLogin: "xatelitte"}
+		if err := c.checkIdentity(id, "id:54596"); err == nil {
+			t.Fatal("expected mismatch error")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/hfr/ -run TestCheckIdentity -v`
+Expected: FAIL — `c.checkIdentity undefined`, `unknown field allowUnguarded/expectedLogin`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/hfr/client.go`, extend the `Client` struct (add the four fields + mutex; keep existing fields):
+
+```go
+import (
+	// ...existing imports...
+	"sync"
+)
+
+type Client struct {
+	http           *http.Client
+	ua             string
+	pseudo         string
+	hashCheck      string
+	authed         bool
+	userID         string // resolved numeric HFR user id ("" if unknown)
+	expectedLogin  string // server-side expected account (HFR_EXPECT_LOGIN)
+	allowUnguarded bool   // HFR_ALLOW_UNGUARDED_WRITES opt-out
+	baseURL        string // injectable; defaults to defaultBaseURL
+	mu             sync.Mutex
+}
+```
+
+Add setters near `NewClient` in `client.go`:
+
+```go
+// SetExpectedLogin sets the server-side expected account guard.
+func (c *Client) SetExpectedLogin(login string) { c.expectedLogin = login }
+
+// SetAllowUnguarded enables writes when no expected account is configured.
+func (c *Client) SetAllowUnguarded(b bool) { c.allowUnguarded = b }
+```
+
+Add `checkIdentity` to `internal/hfr/identity.go`:
+
+```go
+import "fmt" // add to identity.go imports
+
+// checkIdentity enforces the expected-account constraints against id.
+// Fail-closed: with no constraint and no opt-out it refuses.
+func (c *Client) checkIdentity(id Identity, expect string) error {
+	var constraints []string
+	if c.expectedLogin != "" {
+		constraints = append(constraints, c.expectedLogin)
+	}
+	if expect != "" {
+		constraints = append(constraints, expect)
+	}
+	if len(constraints) == 0 {
+		if c.allowUnguarded {
+			return nil
+		}
+		return ErrNoExpectedAccount
+	}
+	for _, want := range constraints {
+		ok, err := identityMatches(id, want)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return &HfrError{Code: "identity", Message: fmt.Sprintf(
+				"write refused: connected as %q (userId %s) != expected %q", id.Pseudo, id.UserID, want)}
+		}
+	}
+	return nil
+}
+```
+
+> Note: `identity.go` now imports both `strings` and `fmt`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/hfr/ -run 'TestCheckIdentity|TestIdentityMatches' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hfr/client.go internal/hfr/identity.go internal/hfr/identity_test.go
+git commit -m "feat(hfr): fail-closed identity guard on Client (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Make baseURL injectable (testability — review #9)
+
+**Files:**
+- Modify: `internal/hfr/client.go` (const rename, `NewClient`, `doPost`, `fetchHashCheck`)
+- Modify: `internal/hfr/reader.go` (`readPage`, `ListTopics`, `FetchQuote`)
+- Modify: `internal/hfr/post.go` (`Edit` editURL)
+
+- [ ] **Step 1: Rename the const and seed the field**
+
+In `client.go` change line 14 from:
+
+```go
+const baseURL = "https://forum.hardware.fr"
+```
+to:
+```go
+const defaultBaseURL = "https://forum.hardware.fr"
+```
+
+In `NewClient` set the field (add `baseURL: defaultBaseURL,` to the returned struct literal):
+
+```go
+func NewClient() *Client {
+	jar, _ := cookiejar.New(nil)
+	return &Client{
+		http: &http.Client{
+			Jar:     jar,
+			Timeout: 30 * time.Second,
+		},
+		ua:      "hfr-mcp/" + Version,
+		baseURL: defaultBaseURL,
+	}
+}
+```
+
+- [ ] **Step 2: Replace every `baseURL` reference with `c.baseURL`**
+
+These are all methods on `*Client`, so `c.baseURL` is in scope. Replace:
+
+- `client.go` Login cookie check: `u, _ := url.Parse(baseURL)` → `u, _ := url.Parse(c.baseURL)`
+- `client.go` `fetchHashCheck`: `c.doGet(baseURL + "/user/editprofil.php?config=hardwarefr.inc")` → `c.doGet(c.baseURL + "/user/editprofil.php?config=hardwarefr.inc")`
+- `client.go` `doPost`: `http.NewRequest("POST", baseURL+endpoint, body)` → `http.NewRequest("POST", c.baseURL+endpoint, body)`
+- `reader.go` `readPage` Sprintf: `baseURL` → `c.baseURL`
+- `reader.go` `ListTopics` Sprintf: `baseURL` → `c.baseURL`
+- `reader.go` `FetchQuote`: `url.Parse(baseURL)` → `url.Parse(c.baseURL)` AND quoteURL Sprintf `baseURL` → `c.baseURL`
+- `post.go` `Edit` editURL Sprintf: `baseURL` → `c.baseURL`
+
+- [ ] **Step 3: Verify the rename is complete**
+
+Run: `grep -rn '\bbaseURL\b' internal/hfr/`
+Expected: only `defaultBaseURL` (the const) and `c.baseURL` references — no bare `baseURL` left.
+
+- [ ] **Step 4: Build + existing tests**
+
+Run: `go build ./... && go test ./internal/hfr/ -v`
+Expected: build OK, Task 1–2 tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hfr/client.go internal/hfr/reader.go internal/hfr/post.go
+git commit -m "refactor(hfr): make baseURL injectable for tests (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Login rollback, userId resolution, currentIdentity, Whoami (review #1, #3, #4, #8)
+
+**Files:**
+- Modify: `internal/hfr/client.go` (`Login`, replace `fetchHashCheck` with `fetchProfile`, add `currentIdentity`, `Whoami`, `parseUserID`)
+- Test: `internal/hfr/login_test.go`
+
+> **Live verification required first.** The exact location of the numeric userId on the authenticated `editprofil` page is not yet confirmed. Before writing `parseUserID`, fetch the real page once with valid creds and inspect it:
+>
+> ```bash
+> go build -o /tmp/hfr ./cmd/hfr/
+> HFR_LOGIN=… HFR_PASSWD=… /tmp/hfr --auth whoami   # (whoami lands in Task 8; for now:)
+> # quick probe: log the editprofil HTML + cookies during a login from a scratch main, OR
+> # inspect cookies: look for a cookie named like "md_user_id"; if absent, grep the page for
+> # the self profile link (profil.php?...user=NNNN / user_id=NNNN) or a hidden input.
+> ```
+>
+> Lock the selector/cookie name from what you observe, then build the test fixture in Step 1 from the *real* markup. The strategy below is cookie-first with an HTML fallback; adjust the fallback selector to match reality.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/hfr/login_test.go`:
+
+```go
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient points a Client at a test server.
+func newTestClient(baseURL string) *Client {
+	c := NewClient()
+	c.baseURL = baseURL
+	return c
+}
+
+// loginMux serves a minimal HFR login + profile. userIDInPage controls whether
+// the editprofil page exposes the numeric id (fallback path).
+func loginMux(t *testing.T, pseudo, userID string, hashOK, userIDInPage bool) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: pseudo, Path: "/"})
+		if userID != "" {
+			http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: userID, Path: "/"})
+		}
+		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		if !hashOK {
+			_, _ = w.Write([]byte("<html><body>no token</body></html>"))
+			return
+		}
+		page := `<html><body><input type="hidden" name="hash_check" value="HASH123">`
+		if userIDInPage {
+			page += `<a href="/user/profil.php?config=hfr.inc&amp;user=` + userID + `">profil</a>`
+		}
+		page += `</body></html>`
+		_, _ = w.Write([]byte(page))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestLoginResolvesIdentity(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "1214571", true, true)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	id, err := c.currentIdentity()
+	if err != nil {
+		t.Fatalf("currentIdentity: %v", err)
+	}
+	if id.Pseudo != "xatelitte" || id.UserID != "1214571" || !id.Authenticated {
+		t.Fatalf("identity = %+v", id)
+	}
+}
+
+func TestLoginRollbackOnHashFailure(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "1214571", false, false)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err == nil {
+		t.Fatal("expected login error when hash_check missing")
+	}
+	if c.authed {
+		t.Fatal("authed must stay false after failed login")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/hfr/ -run TestLogin -v`
+Expected: FAIL — `c.currentIdentity undefined`; rollback test fails because current `Login` sets `authed=true` before the hash step.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `client.go`, rewrite `Login` to commit state only on full success, and replace `fetchHashCheck` with `fetchProfile`:
+
+```go
+func (c *Client) Login(pseudo, password string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	data := url.Values{"pseudo": {pseudo}, "password": {password}}
+	doc, err := c.doPost("/login_validation.php?config=hfr.inc", data)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+	if strings.Contains(doc.Text(), "Votre mot de passe ou nom d'utilisateur n'est pas valide") {
+		return ErrInvalidCreds
+	}
+
+	u, _ := url.Parse(c.baseURL)
+	found := false
+	for _, cookie := range c.http.Jar.Cookies(u) {
+		if cookie.Name == "md_user" && cookie.Value == pseudo {
+			found = true
+		}
+	}
+	if !found {
+		return &HfrError{Code: "auth", Message: "login failed: md_user cookie not set"}
+	}
+
+	hash, userID, err := c.fetchProfile()
+	if err != nil {
+		return err // no state mutated yet
+	}
+
+	c.pseudo = pseudo
+	c.hashCheck = hash
+	c.userID = userID
+	c.authed = true
+	return nil
+}
+
+// fetchProfile loads the authenticated profile page and extracts the
+// anti-CSRF token and (best-effort) the numeric user id.
+func (c *Client) fetchProfile() (hash, userID string, err error) {
+	doc, err := c.doGet(c.baseURL + "/user/editprofil.php?config=hardwarefr.inc")
+	if err != nil {
+		return "", "", fmt.Errorf("profile fetch failed: %w", err)
+	}
+	hash, ok := doc.Find("input[name=hash_check]").Attr("value")
+	if !ok || hash == "" {
+		return "", "", ErrNoHashCheck
+	}
+	return hash, c.parseUserID(doc), nil
+}
+
+// parseUserID resolves the numeric user id, cookie first, page fallback.
+// Returns "" if it cannot be resolved (guard then refuses id: constraints).
+func (c *Client) parseUserID(doc *goquery.Document) string {
+	u, _ := url.Parse(c.baseURL)
+	for _, ck := range c.http.Jar.Cookies(u) {
+		if ck.Name == "md_user_id" && ck.Value != "" {
+			return ck.Value
+		}
+	}
+	// Fallback: a self profile link carrying user=NNNN (adjust to live markup).
+	id := ""
+	doc.Find(`a[href*="user="]`).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		href, _ := s.Attr("href")
+		if i := strings.Index(href, "user="); i >= 0 {
+			rest := href[i+len("user="):]
+			j := 0
+			for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+				j++
+			}
+			if j > 0 {
+				id = rest[:j]
+				return false
+			}
+		}
+		return true
+	})
+	return id
+}
+
+// currentIdentity reads the account behind the live session (cookie authority).
+func (c *Client) currentIdentity() (Identity, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return Identity{}, err
+	}
+	pseudo := ""
+	for _, ck := range c.http.Jar.Cookies(u) {
+		if ck.Name == "md_user" {
+			if v, derr := url.QueryUnescape(ck.Value); derr == nil {
+				pseudo = v
+			} else {
+				pseudo = ck.Value
+			}
+		}
+	}
+	if pseudo == "" {
+		return Identity{}, ErrNotAuthenticated
+	}
+	return Identity{Pseudo: pseudo, UserID: c.userID, Authenticated: true}, nil
+}
+
+// Whoami returns the account currently behind the session.
+func (c *Client) Whoami() (Identity, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.currentIdentity()
+}
+```
+
+Delete the old `fetchHashCheck` method (replaced by `fetchProfile`). Ensure `goquery` is imported in `client.go` (it already is).
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/hfr/ -run TestLogin -v && go build ./...`
+Expected: PASS, build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hfr/client.go internal/hfr/login_test.go
+git commit -m "feat(hfr): resolve identity at login, rollback on failure (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Atomic write path + rewire write methods (review #1, #2, #10)
+
+**Files:**
+- Modify: `internal/hfr/post.go` (`Reply`, `CreateTopic`, `Edit`)
+- Modify: `internal/hfr/mp.go` (`SendMP`)
+- Modify: `internal/hfr/client.go` (add `authenticatedPost`)
+- Test: `internal/hfr/write_guard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/hfr/write_guard_test.go`:
+
+```go
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// writeMux extends loginMux with a reply endpoint that counts POSTs.
+func writeServer(t *testing.T, pseudo, userID string, posted *int32) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: pseudo, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: userID, Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="H">`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(posted, 1)
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestReplyRefusedOnMismatchNoPost(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "XaTriX", "54596", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("XaTriX", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_, err := c.Reply(23, 35421, "hi", "")
+	if err == nil {
+		t.Fatal("expected identity refusal")
+	}
+	if atomic.LoadInt32(&posted) != 0 {
+		t.Fatalf("POST must not be sent on mismatch, got %d", posted)
+	}
+}
+
+func TestReplyAllowedReturnsIdentity(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "xatelitte", "1214571", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	id, err := c.Reply(23, 35421, "hi", "id:1214571")
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if id.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
+		t.Fatalf("id=%+v posted=%d", id, posted)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/hfr/ -run TestReply -v`
+Expected: FAIL — `Reply` signature mismatch (`too many arguments`, no return value).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `authenticatedPost` to `client.go`:
+
+```go
+// authenticatedPost resolves the current identity, enforces the guard, and
+// only then POSTs. Returns the identity used. The whole sequence is atomic.
+func (c *Client) authenticatedPost(endpoint string, data url.Values, expect, errCode string) (Identity, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, err := c.currentIdentity()
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := c.checkIdentity(id, expect); err != nil {
+		return Identity{}, err
+	}
+	doc, err := c.doPost(endpoint, data)
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := checkPostSuccess(doc, errCode); err != nil {
+		return Identity{}, err
+	}
+	return id, nil
+}
+```
+
+Rewrite `Reply` in `post.go` (drop `ensureAuth`/manual `doPost`; keep the form fields):
+
+```go
+func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error) {
+	data := c.baseFormData(strconv.Itoa(cat), content)
+	data.Set("post", strconv.Itoa(postId))
+	data.Set("sujet", c.pseudo)
+	data.Set("numreponse", "")
+	data.Set("numrep", "")
+	data.Set("subcat", "")
+	data.Set("parents", "")
+	data.Set("stickold", "")
+	data.Set("cache", "")
+	data.Set("search_smilies", "")
+	data.Set("ColorUsedMem", "")
+	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "post")
+}
+```
+
+Rewrite `CreateTopic` (same pattern, return `(Identity, error)`, end with `return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "create_topic")`, add `expect string` param, keep its `data.Set(...)` lines, drop `ensureAuth`).
+
+Rewrite `Edit` — the GET stays first (so the re-check inside `authenticatedPost` is the TOCTOU guard right before POST):
+
+```go
+func (c *Client) Edit(cat, postId, numreponse int, content, expect string) (Identity, error) {
+	editURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&numreponse=%d",
+		c.baseURL, cat, postId, numreponse)
+	editDoc, err := c.doGet(editURL)
+	if err != nil {
+		return Identity{}, fmt.Errorf("edit page fetch failed: %w", err)
+	}
+	info := parseEditPage(editDoc)
+
+	data := c.baseFormData(strconv.Itoa(cat), content)
+	data.Set("post", strconv.Itoa(postId))
+	data.Set("numreponse", strconv.Itoa(numreponse))
+	data.Set("dest", "")
+	data.Set("numrep", "")
+	data.Set("parents", "")
+	data.Set("stickold", "")
+	data.Set("cache", "")
+	data.Set("search_smilies", "")
+	data.Set("ColorUsedMem", "")
+	if info.IsFirstPost {
+		data.Set("sujet", info.Subject)
+		data.Set("subcat", info.Subcat)
+	} else {
+		data.Set("sujet", c.pseudo)
+		data.Set("subcat", "")
+	}
+	return c.authenticatedPost("/bdd.php?config=hfr.inc", data, expect, "edit")
+}
+```
+
+Rewrite `SendMP` in `mp.go`:
+
+```go
+func (c *Client) SendMP(dest, subject, content, expect string) (Identity, error) {
+	data := c.baseFormData("prive", content)
+	data.Set("dest", dest)
+	data.Set("sujet", subject)
+	data.Set("post", "")
+	data.Set("numreponse", "")
+	data.Set("numrep", "")
+	data.Set("subcat", "")
+	data.Set("parents", "")
+	data.Set("stickold", "")
+	data.Set("cache", "")
+	data.Set("search_smilies", "")
+	data.Set("ColorUsedMem", "")
+	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "mp")
+}
+```
+
+> `ensureAuth` is now unused by writes (login presence is enforced by `currentIdentity`). Leave it defined (still referenced by `FetchQuote` in `reader.go`).
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/hfr/ -v && go build ./...`
+Expected: hfr package tests PASS. Build of `./cmd/...` will FAIL until Tasks 7–8 update callers — that is expected and fixed there. Confirm the *hfr package test* passes:
+`go test ./internal/hfr/ -run TestReply -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hfr/client.go internal/hfr/post.go internal/hfr/mp.go internal/hfr/write_guard_test.go
+git commit -m "feat(hfr): atomic guarded write path, return Identity (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Config — expected login + opt-out
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/config/config_test.go`:
+
+```go
+package config
+
+import "testing"
+
+func TestLoadIdentityEnv(t *testing.T) {
+	t.Setenv("HFR_LOGIN", "xatelitte")
+	t.Setenv("HFR_PASSWD", "pw")
+	t.Setenv("HFR_EXPECT_LOGIN", "xatelitte")
+	t.Setenv("HFR_ALLOW_UNGUARDED_WRITES", "1")
+	cfg := Load()
+	if cfg.ExpectLogin != "xatelitte" {
+		t.Fatalf("ExpectLogin = %q", cfg.ExpectLogin)
+	}
+	if !cfg.AllowUnguarded {
+		t.Fatal("AllowUnguarded should be true")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestLoadIdentityEnv -v`
+Expected: FAIL — `cfg.ExpectLogin undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the `Config` struct and `Load` in `config.go`:
+
+```go
+type Config struct {
+	Login          string
+	Passwd         string
+	ExpectLogin    string
+	AllowUnguarded bool
+}
+```
+
+Add `expect_login` to the file parser `switch` in `readFile`:
+
+```go
+		case "expect_login":
+			cfg.ExpectLogin = v
+```
+
+Add env overrides at the end of `Load` (before `return cfg`):
+
+```go
+	if v := os.Getenv("HFR_EXPECT_LOGIN"); v != "" {
+		cfg.ExpectLogin = v
+	}
+	if os.Getenv("HFR_ALLOW_UNGUARDED_WRITES") == "1" {
+		cfg.AllowUnguarded = true
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): HFR_EXPECT_LOGIN + HFR_ALLOW_UNGUARDED_WRITES (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: MCP — hfr_whoami, expect fields, wire config
+
+**Files:**
+- Modify: `internal/mcp/tools.go` (inputs, handlers, register `hfr_whoami`)
+- Modify: `cmd/hfr-mcp/main.go` (inject guard config)
+
+- [ ] **Step 1: Add `expect` to write inputs + a WhoamiInput**
+
+In `tools.go`, add `Expect string \`json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"\`` to `ReplyInput`, `EditInput`, `CreateTopicInput`, `MPInput`. Add:
+
+```go
+type WhoamiInput struct{}
+```
+
+- [ ] **Step 2: Register the whoami tool**
+
+In `RegisterTools`, add:
+
+```go
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "hfr_whoami",
+		Description: "Afficher le compte HFR actif (pseudo + userId) et le compte attendu configuré.",
+	}, handleWhoami(client, login))
+```
+
+- [ ] **Step 3: Update write handlers + add whoami handler**
+
+Change the four write handlers to pass `input.Expect` and format the returned identity. Example for `handleReply` (apply the same shape to edit/create_topic/mp):
+
+```go
+func handleReply(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReplyInput, Result] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input ReplyInput) (*mcp.CallToolResult, Result, error) {
+		if err := login(); err != nil {
+			return nil, Result{}, fmt.Errorf("login failed: %w", err)
+		}
+		id, err := client.Reply(input.Cat, input.Post, input.Content, input.Expect)
+		if err != nil {
+			return nil, Result{}, fmt.Errorf("reply failed: %w", err)
+		}
+		return nil, Result{Message: fmt.Sprintf("Message posté sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
+	}
+}
+```
+
+Add the whoami handler:
+
+```go
+func handleWhoami(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[WhoamiInput, Result] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input WhoamiInput) (*mcp.CallToolResult, Result, error) {
+		if err := login(); err != nil {
+			return nil, Result{}, fmt.Errorf("login failed: %w", err)
+		}
+		id, err := client.Whoami()
+		if err != nil {
+			return nil, Result{}, fmt.Errorf("whoami failed: %w", err)
+		}
+		return nil, Result{Message: fmt.Sprintf("Connecté : %s (userId %s).", id.Pseudo, id.UserID)}, nil
+	}
+}
+```
+
+- [ ] **Step 4: Inject guard config in the server**
+
+In `cmd/hfr-mcp/main.go`, after `client := hfr.NewClient()` (line 30):
+
+```go
+	client.SetExpectedLogin(cfg.ExpectLogin)
+	client.SetAllowUnguarded(cfg.AllowUnguarded)
+```
+
+- [ ] **Step 5: Build + commit**
+
+Run: `go build ./... && go vet ./...`
+Expected: OK (MCP callers now match new signatures).
+
+```bash
+git add internal/mcp/tools.go cmd/hfr-mcp/main.go
+git commit -m "feat(mcp): hfr_whoami + expect param + guard wiring (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: CLI — --pseudo flag, whoami subcommand
+
+**Files:**
+- Modify: `cmd/hfr/main.go`
+
+- [ ] **Step 1: Parse `--pseudo` and inject guard**
+
+In `main()`, extend flag parsing after the `--auth` block (lines 40–44). Replace that block with:
+
+```go
+	args := os.Args[1:]
+	auth := false
+	pseudo := ""
+	for len(args) > 0 {
+		switch {
+		case args[0] == "--auth":
+			auth = true
+			args = args[1:]
+		case args[0] == "--pseudo" && len(args) > 1:
+			pseudo = args[1]
+			args = args[2:]
+		default:
+			goto parsed
+		}
+	}
+parsed:
+```
+
+After `client := hfr.NewClient()` and inside the `if auth {` block (after a successful `client.Login`), inject config-based guard plus the flag:
+
+```go
+		client.SetExpectedLogin(cfg.ExpectLogin)
+		client.SetAllowUnguarded(cfg.AllowUnguarded)
+```
+
+(`pseudo` is threaded into the write commands below.) Add `whoami` to the `needsAuth` set by leaving the default (it is not in the read-only list, so `needsAuth` is already true for it).
+
+- [ ] **Step 2: Add the whoami case + thread pseudo into writers**
+
+In the `switch cmd` block add:
+
+```go
+	case "whoami":
+		id, err := client.Whoami()
+		if err != nil {
+			die("whoami failed: %v", err)
+		}
+		fmt.Printf("Connecté : %s (userId %s)\n", id.Pseudo, id.UserID)
+```
+
+Update the four write dispatch calls to pass `pseudo`:
+
+```go
+	case "new":
+		cmdNewTopic(client, args, pseudo)
+	case "reply":
+		cmdReply(client, args, pseudo)
+	case "edit":
+		cmdEdit(client, args, pseudo)
+	case "mp":
+		cmdMP(client, args, pseudo)
+```
+
+- [ ] **Step 3: Update the write command functions**
+
+```go
+func cmdNewTopic(client *hfr.Client, args []string, expect string) {
+	if len(args) < 4 {
+		die("usage: hfr new <cat> <subcat> <subject> <content|--file path>")
+	}
+	cat := mustInt(args[0], "cat")
+	subcat := mustInt(args[1], "subcat")
+	subject := args[2]
+	content := readContent(args[3:])
+	id, err := client.CreateTopic(cat, subcat, subject, content, expect)
+	if err != nil {
+		die("create topic failed: %v", err)
+	}
+	fmt.Printf("Topic created (as %s / userId %s).\n", id.Pseudo, id.UserID)
+}
+
+func cmdReply(client *hfr.Client, args []string, expect string) {
+	if len(args) < 3 {
+		die("usage: hfr reply <cat> <post> <content|--file path>")
+	}
+	cat := mustInt(args[0], "cat")
+	post := mustInt(args[1], "post")
+	content := readContent(args[2:])
+	id, err := client.Reply(cat, post, content, expect)
+	if err != nil {
+		die("reply failed: %v", err)
+	}
+	fmt.Printf("Reply posted (as %s / userId %s).\n", id.Pseudo, id.UserID)
+}
+
+func cmdEdit(client *hfr.Client, args []string, expect string) {
+	if len(args) < 4 {
+		die("usage: hfr edit <cat> <post> <numreponse> <content|--file path>")
+	}
+	cat := mustInt(args[0], "cat")
+	post := mustInt(args[1], "post")
+	numreponse := mustInt(args[2], "numreponse")
+	content := readContent(args[3:])
+	id, err := client.Edit(cat, post, numreponse, content, expect)
+	if err != nil {
+		die("edit failed: %v", err)
+	}
+	fmt.Printf("Post edited (as %s / userId %s).\n", id.Pseudo, id.UserID)
+}
+
+func cmdMP(client *hfr.Client, args []string, expect string) {
+	if len(args) < 3 {
+		die("usage: hfr mp <dest> <subject> <content>")
+	}
+	dest := args[0]
+	subject := args[1]
+	content := strings.Join(args[2:], " ")
+	id, err := client.SendMP(dest, subject, content, expect)
+	if err != nil {
+		die("mp failed: %v", err)
+	}
+	fmt.Printf("MP sent (as %s / userId %s).\n", id.Pseudo, id.UserID)
+}
+```
+
+Update `usage` const: add `whoami` to the command list and `--pseudo <login>` to Options.
+
+- [ ] **Step 4: Build + vet + full test suite**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: build OK, vet OK, all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/hfr/main.go
+git commit -m "feat(cli): --pseudo guard + whoami subcommand (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Docs + version bump
+
+**Files:**
+- Modify: `internal/hfr/version.go`
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Bump version**
+
+`internal/hfr/version.go`: `const Version = "1.2.0"`.
+
+- [ ] **Step 2: CHANGELOG**
+
+Prepend a `## [1.2.0] - 2026-06-14` section: new `hfr_whoami` tool / `hfr whoami` command; `expect` param (MCP) and `--pseudo` flag (CLI); fail-closed identity guard with `HFR_EXPECT_LOGIN` and `HFR_ALLOW_UNGUARDED_WRITES`; write methods now report the account used; login hardening (no partial-auth state).
+
+- [ ] **Step 3: README**
+
+In the Fonctionnalités and Outils MCP tables add `hfr_whoami`. Add `--pseudo` to the CLI options and an Authentification note documenting `HFR_EXPECT_LOGIN` / `HFR_ALLOW_UNGUARDED_WRITES` and the typed `expect` syntax (`pseudo:`, `id:`). (Also fix the pre-existing gap: `hfr_cats` and `hfr_create_topic` are missing from the Outils MCP table.)
+
+- [ ] **Step 4: AGENTS.md**
+
+In "Configuration et authentification (runtime)", document the guard: by default writes require an expected account (`HFR_EXPECT_LOGIN` env / `expect_login=` / `--pseudo` / `expect`); `HFR_ALLOW_UNGUARDED_WRITES=1` to opt out; comparison by pseudo or userId.
+
+- [ ] **Step 5: Final validation + commit**
+
+Run: `go build ./... && go vet ./... && golangci-lint run && go test ./...`
+Expected: all green.
+
+```bash
+git add internal/hfr/version.go CHANGELOG.md README.md AGENTS.md
+git commit -m "docs: document identity guard, bump to v1.2.0 (#32)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final live verification (before opening the PR)
+
+- [ ] Build the CLI and confirm against the real forum (read-only + a guarded refusal):
+
+```bash
+go build -o /tmp/hfr ./cmd/hfr/
+HFR_LOGIN=<agent> HFR_PASSWD=<pw> /tmp/hfr --auth whoami
+# expect: "Connecté : <agent> (userId <n>)" with the CORRECT numeric id (cross-check via `hfr quote`)
+HFR_LOGIN=<agent> HFR_PASSWD=<pw> HFR_EXPECT_LOGIN=someoneelse /tmp/hfr reply 23 99999 "test"
+# expect: refusal, no post
+```
+
+- [ ] If the live `userId` is empty or wrong, fix `parseUserID` (Task 4) and its fixture, then re-run Tasks 4–5 tests.
+- [ ] Open the PR with `Closes #32`, summarizing the guard, the new tool/flag, and the env vars.
+
+## Self-review notes (coverage vs spec)
+
+- Fail-closed + opt-out → Task 2 (`checkIdentity`) + Task 6 (config).
+- Cookie `md_user` as POST authority + atomic path → Task 4 (`currentIdentity`) + Task 5 (`authenticatedPost`).
+- Edit TOCTOU re-check before POST → Task 5 (`Edit` GET first, guard inside `authenticatedPost`).
+- Typed `expect` (`pseudo:`/`id:`), bare numeric → userId, `"0"` real → Task 1.
+- userId fail-closed when unresolved → Task 1 (`identityMatches` error path).
+- Login rollback → Task 4. Mutex on shared client → Tasks 4–5. Injectable baseURL → Task 3.
+- Methods return Identity → Task 5; surfaced in MCP/CLI → Tasks 7–8.
+- `hfr_whoami` / `hfr whoami` → Tasks 7–8. Docs/version → Task 9.

--- a/docs/superpowers/specs/2026-06-14-hfr-identity-guard-design.md
+++ b/docs/superpowers/specs/2026-06-14-hfr-identity-guard-design.md
@@ -2,7 +2,7 @@
 
 **Date** : 2026-06-14
 **Issue** : [#32](https://github.com/ForumHFR/hfr-mcp/issues/32) — écritures sous le mauvais compte HFR
-**Statut** : design validé, prêt pour le plan d'implémentation
+**Statut** : design validé (intègre la review Codex gpt-5.5/xhigh du 2026-06-14), prêt pour le plan d'implémentation
 
 ## Problème
 
@@ -17,8 +17,9 @@ La prévention est donc la seule protection viable.
 ## Objectifs
 
 1. **Savoir** quel compte est actif avant d'écrire (`hfr_whoami` / `hfr whoami`).
-2. **Refuser** d'écrire quand le compte connecté ne correspond pas au compte voulu — déclaré soit côté serveur,
-   soit par commande (défense en profondeur).
+2. **Refuser** d'écrire quand le compte connecté ne correspond pas au compte voulu — déclaré côté serveur
+   (`HFR_EXPECT_LOGIN`) et/ou par appel (`--pseudo` / `expect`), et **refuser par défaut** si aucun compte
+   attendu n'est déclaré (fail-closed).
 3. **Tracer** systématiquement, dans le retour de chaque écriture réussie, le compte effectivement utilisé.
 
 Hors scope : les bugs de l'issue #31 (notif e-mail, cache `hfr_read`), un éventuel `hfr_delete`,
@@ -28,107 +29,151 @@ la sélection/bascule de compte au runtime.
 
 | Décision | Choix retenu |
 |---|---|
-| Déclaration du compte attendu | **Défense en profondeur** : barrière serveur `HFR_EXPECT_LOGIN` (env/`hfr.conf`) **et** paramètre par appel (`--pseudo` CLI / `expect` MCP). |
-| Critère de comparaison | **Pseudo + userId** : une contrainte matche si elle égale le pseudo (insensible à la casse) **ou** le userId numérique. |
-| Comportement par défaut (aucun compte attendu) | **Fail-open** : l'écriture passe, mais le retour affiche toujours le compte utilisé. Le garde-fou strict ne s'active que lorsqu'un compte attendu est déclaré. |
-| Emplacement de la garde | Dans le **`Client` HFR** (`internal/hfr`), point de passage unique pour la CLI et le MCP. |
+| Déclaration du compte attendu | **Défense en profondeur** : barrière serveur `HFR_EXPECT_LOGIN` **et** paramètre par appel (`--pseudo` CLI / `expect` MCP). Les deux contraintes, quand présentes, doivent passer. |
+| Critère de comparaison | **Pseudo + userId**, avec **syntaxe typée** : `pseudo:<nom>`, `id:<n>`. Sans préfixe : un attendu purement numérique vise le userId, sinon le pseudo. `"0"` est une contrainte valide (≠ vide). |
+| Comportement par défaut (aucun compte attendu) | **Fail-closed** : les écritures sont refusées tant qu'aucun compte attendu n'est déclaré, sauf opt-out explicite `HFR_ALLOW_UNGUARDED_WRITES=1` (qui autorise l'écriture en affichant le compte). |
+| Autorité d'identité | Le **cookie `md_user` du jar au moment du POST** (pas une valeur mise en cache au login). |
+| Emplacement de la garde | Dans le **`Client` HFR** (`internal/hfr`), via un chemin d'écriture unique. |
 
 ## Architecture
 
-La logique vit dans le `Client` HFR. La CLI et le serveur MCP ne font que :
-- fournir le compte attendu issu de l'appel (`--pseudo` / champ `expect`) ;
-- fournir le compte attendu serveur (`HFR_EXPECT_LOGIN`) au moment de la construction du client ;
-- formater l'identité renvoyée par le client.
+La logique vit dans le `Client` HFR, derrière un **chemin d'écriture unique** qui rend atomiques
+« résolution de l'identité courante → vérification → POST ». La CLI et le serveur MCP ne font que fournir
+les contraintes (`--pseudo` / `expect`, `HFR_EXPECT_LOGIN`) et formater l'`Identity` renvoyée.
 
-Aucune vérification n'est dupliquée dans les couches d'appel.
+### Autorité d'identité (corrige review #1, #2)
+
+Le compte qui signe réellement un POST est porté par le `CookieJar`, pas par un champ mémorisé. La garde lit
+donc l'identité **courante** juste avant chaque POST :
+
+- `func (c *Client) currentIdentity() (Identity, error)` : lit le cookie `md_user` du jar (pseudo = autorité),
+  associe le `userID` résolu. Erreur si le cookie est absent (session perdue).
+- Pour `Edit`, qui exécute un GET (page d'édition) **avant** le POST, la vérification est refaite
+  immédiatement avant le POST — pas seulement en tête de fonction.
+- Tous les POST d'écriture passent par un helper interne unique (`authenticatedPost`) qui enchaîne
+  `currentIdentity` → `checkIdentity` → `doPost` sous le même verrou.
 
 ## Composants
 
 ### 1. `internal/hfr` — résolution d'identité
 
-- `Client` gagne deux champs : `userID string` et `expectedLogin string`.
+- `Client` gagne `userID string`, `expectedLogin string`, `allowUnguarded bool`, `baseURL string`
+  (injectable pour les tests, défaut = const actuelle — corrige review #9), et un `sync.Mutex`
+  protégeant l'état auth et les écritures (corrige review #8).
 - `type Identity struct { Pseudo string; UserID string; Authenticated bool }`.
-- Au login (dans/après `fetchHashCheck`, qui charge déjà `/user/editprofil.php`), résoudre le userId réel.
-  Source par ordre de préférence : cookie `md_user_id` s'il existe, sinon parse de la page profil
-  (lien/champ exposant l'identifiant). **Si le userId ne peut pas être résolu, `userID` reste vide** et la
-  garde se rabat sur le pseudo seul — pas d'échec dur.
-- `func (c *Client) Whoami() Identity` — renvoie l'identité en cache (zéro requête supplémentaire ;
-  l'appelant déclenche le login lazy au préalable).
+- **Résolution du `userId`** (corrige review #3) : à l'authentification, parser une **source serveur précise
+  sur `/user/editprofil.php`** (déjà chargée par `fetchHashCheck`) — champ/lien exposant l'identifiant ;
+  source exacte à figer à l'implémentation. Si le cookie `md_user_id` existe, le valider contre cette source.
+  **Pas de userId inventé** : s'il reste irrésolu, `userID` est vide.
+- `func (c *Client) Whoami() (Identity, error)` — renvoie l'identité courante (déclenche le login lazy
+  côté appelant au préalable).
 
 ### 2. `internal/hfr` — garde-fou
 
 ```go
-func (c *Client) checkIdentity(expect string) error {
-    for _, want := range []string{c.expectedLogin, expect} {
-        if want == "" {
-            continue // fail-open : contrainte absente
+// want est une contrainte typée : "pseudo:x", "id:n", ou brut (numérique => userId, sinon pseudo).
+func (c *Client) checkIdentity(id Identity, expect string) error {
+    constraints := nonEmpty(c.expectedLogin, expect)
+    if len(constraints) == 0 {
+        if c.allowUnguarded {
+            return nil // opt-out explicite
         }
-        if !c.identityMatches(want) {
-            return &HfrError{Code: "identity", Message: ...}
+        return ErrNoExpectedAccount // fail-closed
+    }
+    for _, want := range constraints {
+        if !identityMatches(id, want) {
+            return ErrIdentityMismatch // message: connecté X (userId N) ≠ attendu want
         }
     }
     return nil
 }
-
-func (c *Client) identityMatches(want string) bool {
-    return strings.EqualFold(want, c.pseudo) || (c.userID != "" && want == c.userID)
-}
 ```
 
-- Appelé en tête de `Reply`, `Edit`, `CreateTopic`, `SendMP`, **après** `ensureAuth`/login et **avant** tout POST.
-- `expectedLogin` (serveur) et `expect` (appel) sont deux contraintes indépendantes : les deux doivent passer.
+- `identityMatches` applique la syntaxe typée et **échoue explicitement si l'attendu vise un userId mais que
+  `id.UserID` est vide** (corrige review #3, #6).
+- Comparaison de pseudo via une fonction `normalize` unique : trim, repli de casse, normalisation Unicode,
+  décodage cookie si nécessaire (corrige review #7).
+- `""` = pas de contrainte ; `"0"` = contrainte réelle (corrige review #6).
 
-### 3. `internal/config` — compte attendu serveur
+### 3. `internal/hfr` — robustesse du login (corrige review #4)
 
-- Lire `HFR_EXPECT_LOGIN` (env) et `expect_login=` dans `hfr.conf`. Optionnel. L'env prime sur le fichier.
-- Transmis au `Client` à la construction.
+`Login` ne doit muter `pseudo`/`authed`/`hashCheck`/`userID` **qu'après succès complet** (cookie `md_user`
+confirmé **et** `fetchHashCheck` réussi **et** `userID` résolu). En cas d'échec intermédiaire : rollback,
+`authed` reste `false`.
 
-### 4. `internal/mcp` — exposition
+### 4. `internal/config` — compte attendu serveur
 
-- Nouvel outil **`hfr_whoami`** (sans paramètre) : déclenche le login lazy, renvoie pseudo + userId +
-  compte attendu serveur.
-- Champ optionnel `expect string` ajouté à `ReplyInput`, `EditInput`, `CreateTopicInput`, `MPInput`,
-  transmis à la méthode du client.
-- Le serveur passe `HFR_EXPECT_LOGIN` au client au démarrage.
-- Les handlers d'écriture, en cas de succès, formatent le compte effectif via `client.Whoami()`.
+- Lire `HFR_EXPECT_LOGIN` (env) + `expect_login=` (`hfr.conf`) ; `HFR_ALLOW_UNGUARDED_WRITES` (env).
+  L'env prime sur le fichier. Transmis au `Client` à la construction (signature `NewClient` étendue
+  ou option fonctionnelle — corrige review #10).
 
-### 5. `cmd/hfr` — CLI
+### 5. `internal/mcp` — exposition
 
-- Flag global **`--pseudo <login>`** : sur les commandes d'écriture, transmis comme `expect`.
-- Nouvelle sous-commande **`hfr whoami`** : login puis affichage pseudo + userId + compte attendu.
-- Lit aussi `HFR_EXPECT_LOGIN` via la config.
+- Nouvel outil **`hfr_whoami`** (sans paramètre) : login lazy, renvoie pseudo + userId + compte attendu
+  + état du garde (gardé / non gardé).
+- Champ optionnel `expect string` ajouté à `ReplyInput`, `EditInput`, `CreateTopicInput`, `MPInput`.
+- Le serveur injecte `HFR_EXPECT_LOGIN` / `HFR_ALLOW_UNGUARDED_WRITES` au client au démarrage.
+- Les handlers formatent l'`Identity` **retournée par la méthode d'écriture** (pas un `Whoami()` post-hoc —
+  corrige review #10).
+
+### 6. `cmd/hfr` — CLI
+
+- Flag global **`--pseudo <login>`** (parsé à côté de `--auth`, aujourd'hui seul géré — corrige review #10) ;
+  transmis comme `expect` sur les écritures.
+- Nouvelle sous-commande **`hfr whoami`**.
+- Lit `HFR_EXPECT_LOGIN` / `HFR_ALLOW_UNGUARDED_WRITES` via la config.
+
+## Signatures (corrige review #10)
+
+```go
+func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error)
+func (c *Client) Edit(cat, postId, numreponse int, content, expect string) (Identity, error)
+func (c *Client) CreateTopic(cat, subcat int, subject, content, expect string) (Identity, error)
+func (c *Client) SendMP(dest, subject, content, expect string) (Identity, error)
+func (c *Client) Whoami() (Identity, error)
+```
 
 ## Comportement (flux)
 
 **Écriture** (`reply`/`edit`/`mp`/`new`) :
-1. login lazy → résolution de l'identité (pseudo + userId) ;
-2. `checkIdentity(expect)` contre `HFR_EXPECT_LOGIN` et le paramètre d'appel ;
-3. si une contrainte échoue → erreur `identity`, **aucun POST** ;
-4. sinon POST, puis retour incluant le compte effectif.
+1. login lazy → résolution de l'identité courante depuis le jar (`currentIdentity`) ;
+2. `checkIdentity` contre `HFR_EXPECT_LOGIN` et l'`expect` d'appel, sous verrou ;
+   - aucune contrainte et pas d'opt-out → `ErrNoExpectedAccount`, **aucun POST** ;
+   - mismatch → `ErrIdentityMismatch`, **aucun POST** ;
+3. (Edit) re-vérification immédiatement avant le POST d'édition ;
+4. POST, puis retour de l'`Identity` utilisée.
 
-**`whoami`** : login → renvoie l'identité. Lecture seule, ne poste rien.
+**`whoami`** : login → renvoie l'identité. Lecture seule.
 
 ## Formats de message
 
-- Succès d'écriture : `Message posté sous xatelitte (userId 1214571).`
-- Refus : `écriture refusée : compte connecté "XaTriX" (54596) ≠ attendu "xatelitte".`
-- `whoami` : `Connecté : xatelitte (userId 1214571). Compte attendu : xatelitte.`
-  (ou `Compte attendu : (non défini)` si aucun).
+- Succès : `Message posté sous xatelitte (userId 1214571).`
+- Refus mismatch : `écriture refusée : compte connecté "XaTriX" (54596) ≠ attendu "xatelitte".`
+- Refus non gardé : `écriture refusée : aucun compte attendu déclaré (pose HFR_EXPECT_LOGIN / --pseudo, ou HFR_ALLOW_UNGUARDED_WRITES=1).`
+- `whoami` : `Connecté : xatelitte (userId 1214571). Compte attendu : xatelitte. Garde : active.`
 
-## Tests
+## Erreurs
 
-Le dépôt n'a pas encore de tests. Ajout de `internal/hfr/identity_test.go` avec un serveur HTTP mock
-(`httptest`) pour le login et la page profil :
+- `ErrNoExpectedAccount` (code `identity`) — fail-closed, aucun compte attendu.
+- `ErrIdentityMismatch` (code `identity`) — compte connecté ≠ attendu, message explicite.
 
-- résolution du userId au login (cookie présent / page parsée / non résolvable → userId vide) ;
-- `identityMatches` : match par pseudo (casse mixte), match par userId, non-match ;
-- `checkIdentity` : contrainte serveur seule, contrainte appel seule, les deux, aucune (fail-open),
-  mismatch sur l'une ou l'autre ;
-- garde appelée avant POST : un mismatch n'émet aucune requête de POST.
+## Tests (corrige review #9)
+
+`internal/hfr` rendu testable via `baseURL`/`http.Client` injectables + serveur `httptest`. Ajout de
+`identity_test.go` :
+
+- résolution du userId au login (source présente / cookie incohérent / irrésolvable → userId vide) ;
+- `Login` : rollback si `fetchHashCheck` échoue (pas d'état `authed` partiel) ;
+- `identityMatches` : `pseudo:` (casse mixte, accents, espaces), `id:`, brut numérique → userId,
+  pseudo numérique, attendu userId mais userID vide → échec, `"0"` ≠ `""` ;
+- `checkIdentity` : contrainte serveur seule, appel seule, les deux, aucune (fail-closed),
+  opt-out `HFR_ALLOW_UNGUARDED_WRITES` ;
+- garde avant POST : un mismatch (et le cas non gardé) **n'émet aucune requête de POST** ;
+- TOCTOU `Edit` : dérive du cookie `md_user` entre le GET et le POST → refus.
 
 ## Impact / compatibilité
 
-- Rétrocompatible : sans `HFR_EXPECT_LOGIN` ni `--pseudo`, le comportement d'écriture est inchangé,
-  enrichi du compte affiché dans le retour.
-- Pas de bump de version requis par ce design seul ; à grouper avec le prochain bump (nouveaux outils →
-  candidat v1.2.0). Mettre à jour `CHANGELOG.md`, le README (tableaux d'outils + section auth) et l'AGENTS.md.
+- **Changement de comportement** : par défaut, les écritures exigent désormais un compte attendu déclaré
+  (fail-closed). Opt-out `HFR_ALLOW_UNGUARDED_WRITES=1` pour le comportement historique.
+- Nouveaux outils/flags → candidat **v1.2.0**. Mettre à jour `CHANGELOG.md`, le README (tableaux d'outils
+  + section auth + nouvelles variables d'env) et l'`AGENTS.md`.

--- a/docs/superpowers/specs/2026-06-14-hfr-identity-guard-design.md
+++ b/docs/superpowers/specs/2026-06-14-hfr-identity-guard-design.md
@@ -1,0 +1,134 @@
+# Garde-fou d'identité HFR (issue #32)
+
+**Date** : 2026-06-14
+**Issue** : [#32](https://github.com/ForumHFR/hfr-mcp/issues/32) — écritures sous le mauvais compte HFR
+**Statut** : design validé, prêt pour le plan d'implémentation
+
+## Problème
+
+Les outils d'écriture (`hfr_reply`, `hfr_edit`, `hfr_mp`, `hfr_create_topic`) publient sous le compte HFR
+déterminé par la configuration de la session (`HFR_LOGIN` / `hfr.conf`). Ce compte peut dériver
+silencieusement d'une session à l'autre, et **rien ne permet de connaître le compte actif avant d'écrire**.
+Résultat constaté plusieurs fois : des messages destinés au compte agent sont partis sous un autre compte.
+
+Le forum n'offre aucun outil de suppression : une écriture sous le mauvais compte doit être retirée à la main.
+La prévention est donc la seule protection viable.
+
+## Objectifs
+
+1. **Savoir** quel compte est actif avant d'écrire (`hfr_whoami` / `hfr whoami`).
+2. **Refuser** d'écrire quand le compte connecté ne correspond pas au compte voulu — déclaré soit côté serveur,
+   soit par commande (défense en profondeur).
+3. **Tracer** systématiquement, dans le retour de chaque écriture réussie, le compte effectivement utilisé.
+
+Hors scope : les bugs de l'issue #31 (notif e-mail, cache `hfr_read`), un éventuel `hfr_delete`,
+la sélection/bascule de compte au runtime.
+
+## Décisions de design
+
+| Décision | Choix retenu |
+|---|---|
+| Déclaration du compte attendu | **Défense en profondeur** : barrière serveur `HFR_EXPECT_LOGIN` (env/`hfr.conf`) **et** paramètre par appel (`--pseudo` CLI / `expect` MCP). |
+| Critère de comparaison | **Pseudo + userId** : une contrainte matche si elle égale le pseudo (insensible à la casse) **ou** le userId numérique. |
+| Comportement par défaut (aucun compte attendu) | **Fail-open** : l'écriture passe, mais le retour affiche toujours le compte utilisé. Le garde-fou strict ne s'active que lorsqu'un compte attendu est déclaré. |
+| Emplacement de la garde | Dans le **`Client` HFR** (`internal/hfr`), point de passage unique pour la CLI et le MCP. |
+
+## Architecture
+
+La logique vit dans le `Client` HFR. La CLI et le serveur MCP ne font que :
+- fournir le compte attendu issu de l'appel (`--pseudo` / champ `expect`) ;
+- fournir le compte attendu serveur (`HFR_EXPECT_LOGIN`) au moment de la construction du client ;
+- formater l'identité renvoyée par le client.
+
+Aucune vérification n'est dupliquée dans les couches d'appel.
+
+## Composants
+
+### 1. `internal/hfr` — résolution d'identité
+
+- `Client` gagne deux champs : `userID string` et `expectedLogin string`.
+- `type Identity struct { Pseudo string; UserID string; Authenticated bool }`.
+- Au login (dans/après `fetchHashCheck`, qui charge déjà `/user/editprofil.php`), résoudre le userId réel.
+  Source par ordre de préférence : cookie `md_user_id` s'il existe, sinon parse de la page profil
+  (lien/champ exposant l'identifiant). **Si le userId ne peut pas être résolu, `userID` reste vide** et la
+  garde se rabat sur le pseudo seul — pas d'échec dur.
+- `func (c *Client) Whoami() Identity` — renvoie l'identité en cache (zéro requête supplémentaire ;
+  l'appelant déclenche le login lazy au préalable).
+
+### 2. `internal/hfr` — garde-fou
+
+```go
+func (c *Client) checkIdentity(expect string) error {
+    for _, want := range []string{c.expectedLogin, expect} {
+        if want == "" {
+            continue // fail-open : contrainte absente
+        }
+        if !c.identityMatches(want) {
+            return &HfrError{Code: "identity", Message: ...}
+        }
+    }
+    return nil
+}
+
+func (c *Client) identityMatches(want string) bool {
+    return strings.EqualFold(want, c.pseudo) || (c.userID != "" && want == c.userID)
+}
+```
+
+- Appelé en tête de `Reply`, `Edit`, `CreateTopic`, `SendMP`, **après** `ensureAuth`/login et **avant** tout POST.
+- `expectedLogin` (serveur) et `expect` (appel) sont deux contraintes indépendantes : les deux doivent passer.
+
+### 3. `internal/config` — compte attendu serveur
+
+- Lire `HFR_EXPECT_LOGIN` (env) et `expect_login=` dans `hfr.conf`. Optionnel. L'env prime sur le fichier.
+- Transmis au `Client` à la construction.
+
+### 4. `internal/mcp` — exposition
+
+- Nouvel outil **`hfr_whoami`** (sans paramètre) : déclenche le login lazy, renvoie pseudo + userId +
+  compte attendu serveur.
+- Champ optionnel `expect string` ajouté à `ReplyInput`, `EditInput`, `CreateTopicInput`, `MPInput`,
+  transmis à la méthode du client.
+- Le serveur passe `HFR_EXPECT_LOGIN` au client au démarrage.
+- Les handlers d'écriture, en cas de succès, formatent le compte effectif via `client.Whoami()`.
+
+### 5. `cmd/hfr` — CLI
+
+- Flag global **`--pseudo <login>`** : sur les commandes d'écriture, transmis comme `expect`.
+- Nouvelle sous-commande **`hfr whoami`** : login puis affichage pseudo + userId + compte attendu.
+- Lit aussi `HFR_EXPECT_LOGIN` via la config.
+
+## Comportement (flux)
+
+**Écriture** (`reply`/`edit`/`mp`/`new`) :
+1. login lazy → résolution de l'identité (pseudo + userId) ;
+2. `checkIdentity(expect)` contre `HFR_EXPECT_LOGIN` et le paramètre d'appel ;
+3. si une contrainte échoue → erreur `identity`, **aucun POST** ;
+4. sinon POST, puis retour incluant le compte effectif.
+
+**`whoami`** : login → renvoie l'identité. Lecture seule, ne poste rien.
+
+## Formats de message
+
+- Succès d'écriture : `Message posté sous xatelitte (userId 1214571).`
+- Refus : `écriture refusée : compte connecté "XaTriX" (54596) ≠ attendu "xatelitte".`
+- `whoami` : `Connecté : xatelitte (userId 1214571). Compte attendu : xatelitte.`
+  (ou `Compte attendu : (non défini)` si aucun).
+
+## Tests
+
+Le dépôt n'a pas encore de tests. Ajout de `internal/hfr/identity_test.go` avec un serveur HTTP mock
+(`httptest`) pour le login et la page profil :
+
+- résolution du userId au login (cookie présent / page parsée / non résolvable → userId vide) ;
+- `identityMatches` : match par pseudo (casse mixte), match par userId, non-match ;
+- `checkIdentity` : contrainte serveur seule, contrainte appel seule, les deux, aucune (fail-open),
+  mismatch sur l'une ou l'autre ;
+- garde appelée avant POST : un mismatch n'émet aucune requête de POST.
+
+## Impact / compatibilité
+
+- Rétrocompatible : sans `HFR_EXPECT_LOGIN` ni `--pseudo`, le comportement d'écriture est inchangé,
+  enrichi du compte affiché dans le retour.
+- Pas de bump de version requis par ce design seul ; à grouper avec le prochain bump (nouveaux outils →
+  candidat v1.2.0). Mettre à jour `CHANGELOG.md`, le README (tableaux d'outils + section auth) et l'AGENTS.md.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,10 @@ import (
 )
 
 type Config struct {
-	Login  string
-	Passwd string
+	Login          string
+	Passwd         string
+	ExpectLogin    string
+	AllowUnguarded bool
 }
 
 // Load reads config from files then overrides with env vars.
@@ -37,6 +39,12 @@ func Load() *Config {
 	}
 	if v := os.Getenv("HFR_PASSWD"); v != "" {
 		cfg.Passwd = v
+	}
+	if v := os.Getenv("HFR_EXPECT_LOGIN"); v != "" {
+		cfg.ExpectLogin = v
+	}
+	if os.Getenv("HFR_ALLOW_UNGUARDED_WRITES") == "1" {
+		cfg.AllowUnguarded = true
 	}
 
 	return cfg
@@ -67,6 +75,8 @@ func readFile(path string, cfg *Config) bool {
 			cfg.Login = v
 		case "passwd":
 			cfg.Passwd = v
+		case "expect_login":
+			cfg.ExpectLogin = v
 		}
 	}
 	return true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestLoadIdentityEnv(t *testing.T) {
+	t.Setenv("HFR_LOGIN", "xatelitte")
+	t.Setenv("HFR_PASSWD", "pw")
+	t.Setenv("HFR_EXPECT_LOGIN", "xatelitte")
+	t.Setenv("HFR_ALLOW_UNGUARDED_WRITES", "1")
+	cfg := Load()
+	if cfg.ExpectLogin != "xatelitte" {
+		t.Fatalf("ExpectLogin = %q", cfg.ExpectLogin)
+	}
+	if !cfg.AllowUnguarded {
+		t.Fatal("AllowUnguarded should be true")
+	}
+}

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-const baseURL = "https://forum.hardware.fr"
+const defaultBaseURL = "https://forum.hardware.fr"
 
 // Client handles all interactions with the HFR forum
 type Client struct {
@@ -24,7 +24,7 @@ type Client struct {
 	userID         string // resolved numeric HFR user id at login ("" if unknown)
 	expectedLogin  string // server-side expected account (HFR_EXPECT_LOGIN)
 	allowUnguarded bool   // HFR_ALLOW_UNGUARDED_WRITES opt-out
-	baseURL        string // injectable; defaults to defaultBaseURL (set in a later task)
+	baseURL        string // injectable (tests); defaults to defaultBaseURL
 	// mu serializes login and the guarded write path (Login / authenticatedPost).
 	// checkIdentity is called by the holder of mu and must NOT lock it itself.
 	// Setters below are init-only (called before the server starts handling calls).
@@ -39,7 +39,8 @@ func NewClient() *Client {
 			Jar:     jar,
 			Timeout: 30 * time.Second,
 		},
-		ua: "hfr-mcp/" + Version,
+		ua:      "hfr-mcp/" + Version,
+		baseURL: defaultBaseURL,
 	}
 }
 
@@ -68,7 +69,7 @@ func (c *Client) Login(pseudo, password string) error {
 	}
 
 	// Check cookie
-	u, _ := url.Parse(baseURL)
+	u, _ := url.Parse(c.baseURL)
 	for _, cookie := range c.http.Jar.Cookies(u) {
 		if cookie.Name == "md_user" && cookie.Value == pseudo {
 			c.pseudo = pseudo
@@ -82,7 +83,7 @@ func (c *Client) Login(pseudo, password string) error {
 
 // fetchHashCheck retrieves the anti-CSRF token
 func (c *Client) fetchHashCheck() error {
-	doc, err := c.doGet(baseURL + "/user/editprofil.php?config=hardwarefr.inc")
+	doc, err := c.doGet(c.baseURL + "/user/editprofil.php?config=hardwarefr.inc")
 	if err != nil {
 		return fmt.Errorf("hash_check failed: %w", err)
 	}
@@ -130,7 +131,7 @@ func (c *Client) baseFormData(cat string, content string) url.Values {
 // doPost sends a POST request and returns the parsed document
 func (c *Client) doPost(endpoint string, data url.Values) (*goquery.Document, error) {
 	body := strings.NewReader(data.Encode())
-	req, err := http.NewRequest("POST", baseURL+endpoint, body)
+	req, err := http.NewRequest("POST", c.baseURL+endpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("post request failed: %w", err)
 	}

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -53,6 +53,10 @@ func (c *Client) SetAllowUnguarded(b bool) { c.allowUnguarded = b }
 // ExpectedLogin returns the configured server-side expected account ("" if none).
 func (c *Client) ExpectedLogin() string { return c.expectedLogin }
 
+// GuardActive reports whether writes are guarded. It is inactive only when no
+// expected account is set and unguarded writes were explicitly opted into.
+func (c *Client) GuardActive() bool { return c.expectedLogin != "" || !c.allowUnguarded }
+
 // Login authenticates with the forum.
 // State is mutated only on full success; any failure leaves authed=false.
 func (c *Client) Login(pseudo, password string) error {

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -170,7 +170,9 @@ func (c *Client) ensureAuth() error {
 	return nil
 }
 
-// baseFormData returns the common form fields for posting
+// baseFormData returns the common form fields for posting.
+// It reads c.pseudo/c.hashCheck without holding c.mu; this is safe because
+// they are written once at login, before any write call (lazy-login model).
 func (c *Client) baseFormData(cat string, content string) url.Values {
 	return url.Values{
 		"hash_check":   {c.hashCheck},
@@ -237,6 +239,30 @@ func (c *Client) doGet(fullURL string) (*goquery.Document, error) {
 	}
 
 	return doc, nil
+}
+
+// authenticatedPost resolves the current identity, enforces the guard, and
+// only then POSTs. Returns the identity used. The identity check and the POST
+// are atomic; any pre-fetch GET (e.g. Edit's edit-page load) is intentionally
+// outside this lock — the guard still re-checks immediately before the POST.
+func (c *Client) authenticatedPost(endpoint string, data url.Values, expect, errCode string) (Identity, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, err := c.currentIdentity()
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := c.checkIdentity(id, expect); err != nil {
+		return Identity{}, err
+	}
+	doc, err := c.doPost(endpoint, data)
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := checkPostSuccess(doc, errCode); err != nil {
+		return Identity{}, err
+	}
+	return id, nil
 }
 
 // checkPostSuccess validates that a POST was successful by checking for errors then the success marker

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
@@ -15,11 +16,19 @@ const baseURL = "https://forum.hardware.fr"
 
 // Client handles all interactions with the HFR forum
 type Client struct {
-	http      *http.Client
-	ua        string
-	pseudo    string
-	hashCheck string
-	authed    bool
+	http           *http.Client
+	ua             string
+	pseudo         string
+	hashCheck      string
+	authed         bool
+	userID         string // resolved numeric HFR user id at login ("" if unknown)
+	expectedLogin  string // server-side expected account (HFR_EXPECT_LOGIN)
+	allowUnguarded bool   // HFR_ALLOW_UNGUARDED_WRITES opt-out
+	baseURL        string // injectable; defaults to defaultBaseURL (set in a later task)
+	// mu serializes login and the guarded write path (Login / authenticatedPost).
+	// checkIdentity is called by the holder of mu and must NOT lock it itself.
+	// Setters below are init-only (called before the server starts handling calls).
+	mu sync.Mutex
 }
 
 // NewClient creates a new HFR client with a cookie jar and timeout
@@ -33,6 +42,12 @@ func NewClient() *Client {
 		ua: "hfr-mcp/" + Version,
 	}
 }
+
+// SetExpectedLogin sets the server-side expected account guard.
+func (c *Client) SetExpectedLogin(login string) { c.expectedLogin = login }
+
+// SetAllowUnguarded enables writes when no expected account is configured.
+func (c *Client) SetAllowUnguarded(b bool) { c.allowUnguarded = b }
 
 // Login authenticates with the forum
 func (c *Client) Login(pseudo, password string) error {
@@ -183,13 +198,13 @@ func checkResponseErrors(doc *goquery.Document) error {
 	body := doc.Text()
 
 	errors := map[string]*HfrError{
-		"Vous n'avez pas les droits pour":                          ErrNoRights,
-		"Afin de prevenir les tentatives de flood":                 ErrFloodLimit,
-		"Afin de prévenir les tentatives de flood":                 ErrFloodLimit,
-		"Ce sujet est fermé":                                       ErrTopicLocked,
-		"Vous devez être identifié":                                ErrSessionExpired,
-		"Vous devez remplir tous les champs avant de poster":       {Code: "post", Message: "content or subject missing"},
-		"Vous devez entrez un destinataire":                        {Code: "post", Message: "recipient missing"},
+		"Vous n'avez pas les droits pour":                    ErrNoRights,
+		"Afin de prevenir les tentatives de flood":           ErrFloodLimit,
+		"Afin de prévenir les tentatives de flood":           ErrFloodLimit,
+		"Ce sujet est fermé":                                 ErrTopicLocked,
+		"Vous devez être identifié":                          ErrSessionExpired,
+		"Vous devez remplir tous les champs avant de poster": {Code: "post", Message: "content or subject missing"},
+		"Vous devez entrez un destinataire":                  {Code: "post", Message: "recipient missing"},
 	}
 
 	for msg, hfrErr := range errors {

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -50,6 +50,9 @@ func (c *Client) SetExpectedLogin(login string) { c.expectedLogin = login }
 // SetAllowUnguarded enables writes when no expected account is configured.
 func (c *Client) SetAllowUnguarded(b bool) { c.allowUnguarded = b }
 
+// ExpectedLogin returns the configured server-side expected account ("" if none).
+func (c *Client) ExpectedLogin() string { return c.expectedLogin }
+
 // Login authenticates with the forum.
 // State is mutated only on full success; any failure leaves authed=false.
 func (c *Client) Login(pseudo, password string) error {

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -50,51 +50,116 @@ func (c *Client) SetExpectedLogin(login string) { c.expectedLogin = login }
 // SetAllowUnguarded enables writes when no expected account is configured.
 func (c *Client) SetAllowUnguarded(b bool) { c.allowUnguarded = b }
 
-// Login authenticates with the forum
+// Login authenticates with the forum.
+// State is mutated only on full success; any failure leaves authed=false.
 func (c *Client) Login(pseudo, password string) error {
-	data := url.Values{
-		"pseudo":   {pseudo},
-		"password": {password},
-	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
+	data := url.Values{"pseudo": {pseudo}, "password": {password}}
 	doc, err := c.doPost("/login_validation.php?config=hfr.inc", data)
 	if err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
-
-	body := doc.Text()
-
-	if strings.Contains(body, "Votre mot de passe ou nom d'utilisateur n'est pas valide") {
+	if strings.Contains(doc.Text(), "Votre mot de passe ou nom d'utilisateur n'est pas valide") {
 		return ErrInvalidCreds
 	}
 
-	// Check cookie
 	u, _ := url.Parse(c.baseURL)
+	found := false
 	for _, cookie := range c.http.Jar.Cookies(u) {
 		if cookie.Name == "md_user" && cookie.Value == pseudo {
-			c.pseudo = pseudo
-			c.authed = true
-			return c.fetchHashCheck()
+			found = true
+			break
 		}
 	}
+	if !found {
+		return &HfrError{Code: "auth", Message: "login failed: md_user cookie not set"}
+	}
 
-	return &HfrError{Code: "auth", Message: "login failed: md_user cookie not set"}
+	hash, userID, err := c.fetchProfile()
+	if err != nil {
+		return err // no state mutated yet
+	}
+
+	c.pseudo = pseudo
+	c.hashCheck = hash
+	c.userID = userID
+	c.authed = true
+	return nil
 }
 
-// fetchHashCheck retrieves the anti-CSRF token
-func (c *Client) fetchHashCheck() error {
+// fetchProfile loads the authenticated profile page and extracts the
+// anti-CSRF token and (best-effort) the numeric user id.
+func (c *Client) fetchProfile() (hash, userID string, err error) {
 	doc, err := c.doGet(c.baseURL + "/user/editprofil.php?config=hardwarefr.inc")
 	if err != nil {
-		return fmt.Errorf("hash_check failed: %w", err)
+		return "", "", fmt.Errorf("profile fetch failed: %w", err)
 	}
-
-	hash, exists := doc.Find("input[name=hash_check]").Attr("value")
-	if !exists || hash == "" {
-		return ErrNoHashCheck
+	hash, ok := doc.Find("input[name=hash_check]").Attr("value")
+	if !ok || hash == "" {
+		return "", "", ErrNoHashCheck
 	}
+	return hash, c.parseUserID(doc), nil
+}
 
-	c.hashCheck = hash
-	return nil
+// parseUserID resolves the numeric user id, cookie first, page fallback.
+// Returns "" if it cannot be resolved (guard then refuses id: constraints).
+func (c *Client) parseUserID(doc *goquery.Document) string {
+	u, _ := url.Parse(c.baseURL)
+	for _, ck := range c.http.Jar.Cookies(u) {
+		if ck.Name == "md_user_id" && ck.Value != "" {
+			return ck.Value
+		}
+	}
+	// Fallback: a self profile link carrying user=NNNN (adjust to live markup).
+	id := ""
+	doc.Find(`a[href*="user="]`).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		href, _ := s.Attr("href")
+		if i := strings.Index(href, "user="); i >= 0 {
+			rest := href[i+len("user="):]
+			j := 0
+			for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+				j++
+			}
+			if j > 0 {
+				id = rest[:j]
+				return false
+			}
+		}
+		return true
+	})
+	return id
+}
+
+// currentIdentity reads the account behind the live session (cookie authority).
+// It does not lock c.mu; callers that need atomicity hold it.
+func (c *Client) currentIdentity() (Identity, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return Identity{}, err
+	}
+	pseudo := ""
+	for _, ck := range c.http.Jar.Cookies(u) {
+		if ck.Name == "md_user" {
+			if v, derr := url.QueryUnescape(ck.Value); derr == nil {
+				pseudo = v
+			} else {
+				pseudo = ck.Value
+			}
+		}
+	}
+	if pseudo == "" {
+		return Identity{}, ErrNotAuthenticated
+	}
+	return Identity{Pseudo: pseudo, UserID: c.userID, Authenticated: true}, nil
+}
+
+// Whoami returns the account currently behind the session.
+func (c *Client) Whoami() (Identity, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.currentIdentity()
 }
 
 // ensureAuth checks that the client is authenticated

--- a/internal/hfr/errors.go
+++ b/internal/hfr/errors.go
@@ -13,11 +13,12 @@ func (e *HfrError) Error() string {
 }
 
 var (
-	ErrNotAuthenticated = &HfrError{Code: "auth", Message: "not authenticated"}
-	ErrInvalidCreds     = &HfrError{Code: "auth", Message: "invalid credentials"}
-	ErrSessionExpired   = &HfrError{Code: "auth", Message: "session expired"}
-	ErrNoHashCheck      = &HfrError{Code: "hash", Message: "could not extract hash_check"}
-	ErrFloodLimit       = &HfrError{Code: "flood", Message: "flood limit reached"}
-	ErrNoRights         = &HfrError{Code: "rights", Message: "no rights to edit this message"}
-	ErrTopicLocked      = &HfrError{Code: "locked", Message: "topic is locked"}
+	ErrNotAuthenticated  = &HfrError{Code: "auth", Message: "not authenticated"}
+	ErrInvalidCreds      = &HfrError{Code: "auth", Message: "invalid credentials"}
+	ErrSessionExpired    = &HfrError{Code: "auth", Message: "session expired"}
+	ErrNoHashCheck       = &HfrError{Code: "hash", Message: "could not extract hash_check"}
+	ErrFloodLimit        = &HfrError{Code: "flood", Message: "flood limit reached"}
+	ErrNoRights          = &HfrError{Code: "rights", Message: "no rights to edit this message"}
+	ErrTopicLocked       = &HfrError{Code: "locked", Message: "topic is locked"}
+	ErrNoExpectedAccount = &HfrError{Code: "identity", Message: "write refused: no expected account configured (set HFR_EXPECT_LOGIN / --pseudo, or HFR_ALLOW_UNGUARDED_WRITES=1)"}
 )

--- a/internal/hfr/identity.go
+++ b/internal/hfr/identity.go
@@ -1,6 +1,9 @@
 package hfr
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // Identity is the account currently behind the session.
 type Identity struct {
@@ -46,6 +49,37 @@ func parseExpect(want string) (isID bool, value string) {
 		}
 		return false, w
 	}
+}
+
+// checkIdentity enforces the expected-account constraints against id.
+// Fail-closed: with no constraint and no opt-out it refuses.
+// The caller must hold c.mu (it runs inside the guarded write path); it does
+// not lock itself, to stay reentrant-safe under authenticatedPost.
+func (c *Client) checkIdentity(id Identity, expect string) error {
+	var constraints []string
+	if c.expectedLogin != "" {
+		constraints = append(constraints, c.expectedLogin)
+	}
+	if expect != "" {
+		constraints = append(constraints, expect)
+	}
+	if len(constraints) == 0 {
+		if c.allowUnguarded {
+			return nil
+		}
+		return ErrNoExpectedAccount
+	}
+	for _, want := range constraints {
+		ok, err := identityMatches(id, want)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return &HfrError{Code: "identity", Message: fmt.Sprintf(
+				"write refused: connected as %q (userId %s) != expected %q", id.Pseudo, id.UserID, want)}
+		}
+	}
+	return nil
 }
 
 // identityMatches reports whether id satisfies the constraint want.

--- a/internal/hfr/identity.go
+++ b/internal/hfr/identity.go
@@ -1,0 +1,62 @@
+package hfr
+
+import "strings"
+
+// Identity is the account currently behind the session.
+type Identity struct {
+	Pseudo string
+	UserID string
+	// Authenticated is set by currentIdentity; false when constructed directly.
+	Authenticated bool
+}
+
+// normalize folds case and trims surrounding space for pseudo comparison.
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// isAllDigits reports whether s is a non-empty string of ASCII decimal digits.
+// The empty check is load-bearing: it stops an empty constraint from being read
+// as a numeric userId.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseExpect splits a typed constraint.
+// "id:123" -> (true,"123"); "pseudo:xat" -> (false,"xat");
+// bare all-digits -> (true, digits); otherwise (false, trimmed).
+func parseExpect(want string) (isID bool, value string) {
+	w := strings.TrimSpace(want)
+	switch {
+	case strings.HasPrefix(w, "id:"):
+		return true, strings.TrimSpace(strings.TrimPrefix(w, "id:"))
+	case strings.HasPrefix(w, "pseudo:"):
+		return false, strings.TrimSpace(strings.TrimPrefix(w, "pseudo:"))
+	default:
+		if isAllDigits(w) {
+			return true, w
+		}
+		return false, w
+	}
+}
+
+// identityMatches reports whether id satisfies the constraint want.
+// It errors if want targets a userId the session could not resolve.
+func identityMatches(id Identity, want string) (bool, error) {
+	isID, val := parseExpect(want)
+	if isID {
+		if id.UserID == "" {
+			return false, &HfrError{Code: "identity", Message: "expected account is a userId but the session userId could not be resolved"}
+		}
+		return val == id.UserID, nil
+	}
+	return normalize(val) == normalize(id.Pseudo), nil
+}

--- a/internal/hfr/identity_test.go
+++ b/internal/hfr/identity_test.go
@@ -1,0 +1,42 @@
+package hfr
+
+import "testing"
+
+func TestIdentityMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      Identity
+		want    string
+		ok      bool
+		wantErr bool
+	}{
+		{"pseudo exact", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "xatelitte", true, false},
+		{"pseudo case+space", Identity{Pseudo: "xatelitte"}, "  XaTeLitte ", true, false},
+		{"pseudo mismatch", Identity{Pseudo: "XaTriX"}, "xatelitte", false, false},
+		{"pseudo prefix", Identity{Pseudo: "xatelitte"}, "pseudo:xatelitte", true, false},
+		{"id prefix match", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "id:1214571", true, false},
+		{"id prefix mismatch", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "id:54596", false, false},
+		{"bare numeric -> userId", Identity{Pseudo: "xatelitte", UserID: "1214571"}, "1214571", true, false},
+		{"numeric pseudo via prefix", Identity{Pseudo: "1234"}, "pseudo:1234", true, false},
+		{"id wanted but unresolved", Identity{Pseudo: "xatelitte", UserID: ""}, "id:1214571", false, true},
+		{"zero is a real constraint", Identity{Pseudo: "x", UserID: "5"}, "0", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := identityMatches(tc.id, tc.want)
+			if tc.wantErr {
+				he, isHfr := err.(*HfrError)
+				if !isHfr || he.Code != "identity" {
+					t.Fatalf("err = %v, want *HfrError code=identity", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err = %v", err)
+			}
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/hfr/identity_test.go
+++ b/internal/hfr/identity_test.go
@@ -2,6 +2,48 @@ package hfr
 
 import "testing"
 
+func TestCheckIdentity(t *testing.T) {
+	id := Identity{Pseudo: "xatelitte", UserID: "1214571", Authenticated: true}
+
+	t.Run("no constraint, fail-closed", func(t *testing.T) {
+		c := &Client{}
+		if err := c.checkIdentity(id, ""); err != ErrNoExpectedAccount {
+			t.Fatalf("got %v, want ErrNoExpectedAccount", err)
+		}
+	})
+	t.Run("no constraint, opt-out allows", func(t *testing.T) {
+		c := &Client{allowUnguarded: true}
+		if err := c.checkIdentity(id, ""); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+	t.Run("server constraint match", func(t *testing.T) {
+		c := &Client{expectedLogin: "xatelitte"}
+		if err := c.checkIdentity(id, ""); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+	t.Run("server constraint mismatch", func(t *testing.T) {
+		c := &Client{expectedLogin: "XaTriX"}
+		err := c.checkIdentity(id, "")
+		if he, ok := err.(*HfrError); !ok || he.Code != "identity" {
+			t.Fatalf("got %v, want identity error", err)
+		}
+	})
+	t.Run("all constraints must pass: server match + call mismatch", func(t *testing.T) {
+		c := &Client{expectedLogin: "xatelitte"}
+		if err := c.checkIdentity(id, "id:54596"); err == nil {
+			t.Fatal("expected mismatch error")
+		}
+	})
+	t.Run("opt-out does not bypass an active constraint", func(t *testing.T) {
+		c := &Client{allowUnguarded: true, expectedLogin: "XaTriX"}
+		if err := c.checkIdentity(id, ""); err == nil {
+			t.Fatal("expected identity error despite allowUnguarded")
+		}
+	})
+}
+
 func TestIdentityMatches(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/hfr/login_test.go
+++ b/internal/hfr/login_test.go
@@ -1,0 +1,109 @@
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient points a Client at a test server.
+func newTestClient(baseURL string) *Client {
+	c := NewClient()
+	c.baseURL = baseURL
+	return c
+}
+
+// loginMux serves a minimal HFR login + profile. cookieUserID controls the
+// md_user_id cookie (primary userId source); pageUserID controls the user=NNNN
+// profile link in editprofil (fallback source). Either may be empty.
+func loginMux(t *testing.T, pseudo, cookieUserID, pageUserID string, hashOK bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: pseudo, Path: "/"})
+		if cookieUserID != "" {
+			http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: cookieUserID, Path: "/"})
+		}
+		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		if !hashOK {
+			_, _ = w.Write([]byte("<html><body>no token</body></html>"))
+			return
+		}
+		page := `<html><body><input type="hidden" name="hash_check" value="HASH123">`
+		if pageUserID != "" {
+			page += `<a href="/user/profil.php?config=hfr.inc&amp;user=` + pageUserID + `">profil</a>`
+		}
+		page += `</body></html>`
+		_, _ = w.Write([]byte(page))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestLoginResolvesIdentity(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "1214571", "1214571", true)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	id, err := c.currentIdentity()
+	if err != nil {
+		t.Fatalf("currentIdentity: %v", err)
+	}
+	if id.Pseudo != "xatelitte" || id.UserID != "1214571" || !id.Authenticated {
+		t.Fatalf("identity = %+v", id)
+	}
+}
+
+// userId resolves from the md_user_id cookie alone (no profile link).
+func TestLoginUserIDFromCookie(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "1214571", "", true)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if c.userID != "1214571" {
+		t.Fatalf("userID = %q, want 1214571 (cookie path)", c.userID)
+	}
+}
+
+// userId resolves from the editprofil page link when no cookie is present.
+func TestLoginUserIDFromPageFallback(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "", "1214571", true)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if c.userID != "1214571" {
+		t.Fatalf("userID = %q, want 1214571 (page fallback)", c.userID)
+	}
+}
+
+func TestLoginRollbackOnHashFailure(t *testing.T) {
+	srv := loginMux(t, "xatelitte", "1214571", "", false)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err == nil {
+		t.Fatal("expected login error when hash_check missing")
+	}
+	if c.authed {
+		t.Fatal("authed must stay false after failed login")
+	}
+}
+
+// The server logs in a different account than requested: login must fail.
+func TestLoginMismatchedCookie(t *testing.T) {
+	srv := loginMux(t, "someoneelse", "54596", "", true)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	if err := c.Login("xatelitte", "pw"); err == nil {
+		t.Fatal("expected login error when md_user cookie != requested pseudo")
+	}
+	if c.authed {
+		t.Fatal("authed must stay false after mismatched login")
+	}
+}

--- a/internal/hfr/mp.go
+++ b/internal/hfr/mp.go
@@ -1,11 +1,7 @@
 package hfr
 
 // SendMP sends a private message
-func (c *Client) SendMP(dest, subject, content string) error {
-	if err := c.ensureAuth(); err != nil {
-		return err
-	}
-
+func (c *Client) SendMP(dest, subject, content, expect string) (Identity, error) {
 	data := c.baseFormData("prive", content)
 	data.Set("dest", dest)
 	data.Set("sujet", subject)
@@ -18,11 +14,5 @@ func (c *Client) SendMP(dest, subject, content string) error {
 	data.Set("cache", "")
 	data.Set("search_smilies", "")
 	data.Set("ColorUsedMem", "")
-
-	doc, err := c.doPost("/bddpost.php?config=hfr.inc", data)
-	if err != nil {
-		return err
-	}
-
-	return checkPostSuccess(doc, "mp")
+	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "mp")
 }

--- a/internal/hfr/post.go
+++ b/internal/hfr/post.go
@@ -6,11 +6,7 @@ import (
 )
 
 // Reply posts a new message on a topic
-func (c *Client) Reply(cat, postId int, content string) error {
-	if err := c.ensureAuth(); err != nil {
-		return err
-	}
-
+func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error) {
 	data := c.baseFormData(strconv.Itoa(cat), content)
 	data.Set("post", strconv.Itoa(postId))
 	data.Set("sujet", c.pseudo)
@@ -22,21 +18,11 @@ func (c *Client) Reply(cat, postId int, content string) error {
 	data.Set("cache", "")
 	data.Set("search_smilies", "")
 	data.Set("ColorUsedMem", "")
-
-	doc, err := c.doPost("/bddpost.php?config=hfr.inc", data)
-	if err != nil {
-		return err
-	}
-
-	return checkPostSuccess(doc, "post")
+	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "post")
 }
 
 // CreateTopic creates a new topic in a category
-func (c *Client) CreateTopic(cat, subcat int, subject, content string) error {
-	if err := c.ensureAuth(); err != nil {
-		return err
-	}
-
+func (c *Client) CreateTopic(cat, subcat int, subject, content, expect string) (Identity, error) {
 	data := c.baseFormData(strconv.Itoa(cat), content)
 	data.Set("post", "")
 	data.Set("sujet", subject)
@@ -48,30 +34,17 @@ func (c *Client) CreateTopic(cat, subcat int, subject, content string) error {
 	data.Set("cache", "cache")
 	data.Set("search_smilies", "")
 	data.Set("ColorUsedMem", "")
-
-	doc, err := c.doPost("/bddpost.php?config=hfr.inc", data)
-	if err != nil {
-		return err
-	}
-
-	return checkPostSuccess(doc, "create_topic")
+	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "create_topic")
 }
 
 // Edit modifies an existing post
-func (c *Client) Edit(cat, postId, numreponse int, content string) error {
-	if err := c.ensureAuth(); err != nil {
-		return err
-	}
-
-	// Fetch the edit page to detect FP and extract subcat/subject
+func (c *Client) Edit(cat, postId, numreponse int, content, expect string) (Identity, error) {
 	editURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&numreponse=%d",
 		c.baseURL, cat, postId, numreponse)
-
 	editDoc, err := c.doGet(editURL)
 	if err != nil {
-		return fmt.Errorf("edit page fetch failed: %w", err)
+		return Identity{}, fmt.Errorf("edit page fetch failed: %w", err)
 	}
-
 	info := parseEditPage(editDoc)
 
 	data := c.baseFormData(strconv.Itoa(cat), content)
@@ -84,7 +57,6 @@ func (c *Client) Edit(cat, postId, numreponse int, content string) error {
 	data.Set("cache", "")
 	data.Set("search_smilies", "")
 	data.Set("ColorUsedMem", "")
-
 	if info.IsFirstPost {
 		data.Set("sujet", info.Subject)
 		data.Set("subcat", info.Subcat)
@@ -92,11 +64,5 @@ func (c *Client) Edit(cat, postId, numreponse int, content string) error {
 		data.Set("sujet", c.pseudo)
 		data.Set("subcat", "")
 	}
-
-	doc, err := c.doPost("/bdd.php?config=hfr.inc", data)
-	if err != nil {
-		return err
-	}
-
-	return checkPostSuccess(doc, "edit")
+	return c.authenticatedPost("/bdd.php?config=hfr.inc", data, expect, "edit")
 }

--- a/internal/hfr/post.go
+++ b/internal/hfr/post.go
@@ -65,7 +65,7 @@ func (c *Client) Edit(cat, postId, numreponse int, content string) error {
 
 	// Fetch the edit page to detect FP and extract subcat/subject
 	editURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&numreponse=%d",
-		baseURL, cat, postId, numreponse)
+		c.baseURL, cat, postId, numreponse)
 
 	editDoc, err := c.doGet(editURL)
 	if err != nil {

--- a/internal/hfr/reader.go
+++ b/internal/hfr/reader.go
@@ -20,7 +20,7 @@ func (c *Client) readPage(cat, postId, page int, print bool) (*Topic, error) {
 		printVal = 1
 	}
 	topicURL := fmt.Sprintf("%s/forum2.php?config=hfr.inc&cat=%d&post=%d&page=%d&p=1&sondage=0&owntopic=0&trash=0&trash_post=0&print=%d&numreponse=0&quote_only=0&new=0&nojs=0",
-		baseURL, cat, postId, page, printVal)
+		c.baseURL, cat, postId, page, printVal)
 
 	doc, err := c.doGet(topicURL)
 	if err != nil {
@@ -162,7 +162,7 @@ func (c *Client) ListTopics(cat, subcat, page int) (*TopicList, error) {
 		page = 1
 	}
 	listURL := fmt.Sprintf("%s/forum1.php?config=hfr.inc&cat=%d&subcat=%d&page=%d&sondage=0&owntopic=0&trash=0&trash_post=0&moderation=0&new=0&nojs=0&subcatgroup=0",
-		baseURL, cat, subcat, page)
+		c.baseURL, cat, subcat, page)
 
 	doc, err := c.doGet(listURL)
 	if err != nil {
@@ -189,7 +189,7 @@ func (c *Client) FetchQuote(cat, postId int, numreponses ...int) (string, error)
 	}
 
 	// Set multiquote cookie: quoteshardwarefr-{cat}-{post}=|num1|num2|...
-	u, _ := url.Parse(baseURL)
+	u, _ := url.Parse(c.baseURL)
 	cookieVal := ""
 	for _, nr := range numreponses {
 		cookieVal += fmt.Sprintf("|%d", nr)
@@ -200,7 +200,7 @@ func (c *Client) FetchQuote(cat, postId int, numreponses ...int) (string, error)
 	}})
 
 	quoteURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&numrep=%d&page=1&p=1&new=0",
-		baseURL, cat, postId, numreponses[0])
+		c.baseURL, cat, postId, numreponses[0])
 
 	doc, err := c.doGet(quoteURL)
 	if err != nil {

--- a/internal/hfr/version.go
+++ b/internal/hfr/version.go
@@ -1,4 +1,4 @@
 package hfr
 
 // Version is the current release version of hfr-mcp.
-const Version = "1.1.0"
+const Version = "1.2.0"

--- a/internal/hfr/write_guard_test.go
+++ b/internal/hfr/write_guard_test.go
@@ -91,6 +91,45 @@ func TestEditRefusedOnMismatchNoPost(t *testing.T) {
 	}
 }
 
+// TOCTOU: the session drifts to another account during Edit's pre-POST GET.
+// The guard re-reads the live cookie before the POST, so the edit is refused.
+func TestEditRefusedOnCookieDriftNoPost(t *testing.T) {
+	var posted int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="H">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// Drift: the session flips to another account between the GET and the POST.
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "XaTriX", Path: "/"})
+		_, _ = w.Write([]byte(`<html><body></body></html>`))
+	})
+	mux.HandleFunc("/bdd.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&posted, 1)
+		_, _ = w.Write([]byte("Message édité avec succès"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_, err := c.Edit(23, 35421, 74497677, "x", "")
+	if err == nil {
+		t.Fatal("expected refusal after mid-call cookie drift")
+	}
+	if atomic.LoadInt32(&posted) != 0 {
+		t.Fatalf("edit POST must not be sent after drift, got %d", posted)
+	}
+}
+
 // With no expected account configured but the explicit opt-out, a write goes through.
 func TestReplyAllowedWhenUnguarded(t *testing.T) {
 	var posted int32

--- a/internal/hfr/write_guard_test.go
+++ b/internal/hfr/write_guard_test.go
@@ -1,0 +1,111 @@
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// writeServer logs in as pseudo/userID and counts write POSTs (bddpost.php for
+// reply/mp/new, bdd.php for edit). message.php serves a minimal edit page so
+// Edit's pre-POST GET succeeds.
+func writeServer(t *testing.T, pseudo, userID string, posted *int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: pseudo, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: userID, Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="H">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><body></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(posted, 1)
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	mux.HandleFunc("/bdd.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(posted, 1)
+		_, _ = w.Write([]byte("Message édité avec succès"))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestReplyRefusedOnMismatchNoPost(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "XaTriX", "54596", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("XaTriX", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_, err := c.Reply(23, 35421, "hi", "")
+	if err == nil {
+		t.Fatal("expected identity refusal")
+	}
+	if atomic.LoadInt32(&posted) != 0 {
+		t.Fatalf("POST must not be sent on mismatch, got %d", posted)
+	}
+}
+
+func TestReplyAllowedReturnsIdentity(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "xatelitte", "1214571", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	id, err := c.Reply(23, 35421, "hi", "id:1214571")
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if id.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
+		t.Fatalf("id=%+v posted=%d", id, atomic.LoadInt32(&posted))
+	}
+}
+
+// Edit goes through the same guard; a mismatch must not reach the bdd.php POST,
+// even though Edit does a GET on message.php first.
+func TestEditRefusedOnMismatchNoPost(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "XaTriX", "54596", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("XaTriX", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_, err := c.Edit(23, 35421, 74497677, "x", "")
+	if err == nil {
+		t.Fatal("expected identity refusal")
+	}
+	if atomic.LoadInt32(&posted) != 0 {
+		t.Fatalf("edit POST must not be sent on mismatch, got %d", posted)
+	}
+}
+
+// With no expected account configured but the explicit opt-out, a write goes through.
+func TestReplyAllowedWhenUnguarded(t *testing.T) {
+	var posted int32
+	srv := writeServer(t, "xatelitte", "1214571", &posted)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	c.SetAllowUnguarded(true)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	id, err := c.Reply(23, 35421, "hi", "")
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if id.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
+		t.Fatalf("id=%+v posted=%d", id, atomic.LoadInt32(&posted))
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -26,6 +26,7 @@ type ReplyInput struct {
 	Cat     int    `json:"cat" jsonschema:"Numero de categorie HFR"`
 	Post    int    `json:"post" jsonschema:"Numero du topic"`
 	Content string `json:"content" jsonschema:"Contenu du message en BBCode HFR"`
+	Expect  string `json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"`
 }
 
 type EditInput struct {
@@ -33,12 +34,14 @@ type EditInput struct {
 	Post       int    `json:"post" jsonschema:"Numero du topic"`
 	Numreponse int    `json:"numreponse" jsonschema:"Numero du message a editer"`
 	Content    string `json:"content" jsonschema:"Nouveau contenu en BBCode HFR"`
+	Expect     string `json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"`
 }
 
 type MPInput struct {
 	Dest    string `json:"dest" jsonschema:"Pseudo du destinataire"`
 	Subject string `json:"subject" jsonschema:"Sujet du MP"`
 	Content string `json:"content" jsonschema:"Contenu du message en BBCode HFR"`
+	Expect  string `json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"`
 }
 
 type TopicsInput struct {
@@ -52,6 +55,7 @@ type CreateTopicInput struct {
 	Subcat  int    `json:"subcat" jsonschema:"Numero de sous-categorie HFR"`
 	Subject string `json:"subject" jsonschema:"Titre du topic"`
 	Content string `json:"content" jsonschema:"Contenu du premier post en BBCode HFR"`
+	Expect  string `json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"`
 }
 
 type CatsInput struct {
@@ -64,6 +68,8 @@ type QuoteInput struct {
 	Numreponse  int   `json:"numreponse,omitempty" jsonschema:"Numero du message a citer (simple quote)"`
 	Numreponses []int `json:"numreponses,omitempty" jsonschema:"Numeros des messages a citer (multiquote)"`
 }
+
+type WhoamiInput struct{}
 
 // Output struct
 type Result struct {
@@ -114,6 +120,11 @@ func RegisterTools(srv *mcp.Server, client *hfr.Client, login LoginFunc) {
 		Name:        "hfr_quote",
 		Description: "Recuperer le BBCode de citation d'un ou plusieurs messages HFR. Utiliser numreponse pour un seul message, numreponses pour un multiquote.",
 	}, handleQuote(client, login))
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "hfr_whoami",
+		Description: "Afficher le compte HFR actif (pseudo + userId) et le compte attendu configuré.",
+	}, handleWhoami(client, login))
 }
 
 func handleRead(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReadInput, Result] {
@@ -160,10 +171,11 @@ func handleReply(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReplyIn
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
 		}
-		if err := client.Reply(input.Cat, input.Post, input.Content); err != nil {
+		id, err := client.Reply(input.Cat, input.Post, input.Content, input.Expect)
+		if err != nil {
 			return nil, Result{}, fmt.Errorf("reply failed: %w", err)
 		}
-		return nil, Result{Message: "Message poste avec succes."}, nil
+		return nil, Result{Message: fmt.Sprintf("Message posté sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
 	}
 }
 
@@ -172,10 +184,11 @@ func handleEdit(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[EditInpu
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
 		}
-		if err := client.Edit(input.Cat, input.Post, input.Numreponse, input.Content); err != nil {
+		id, err := client.Edit(input.Cat, input.Post, input.Numreponse, input.Content, input.Expect)
+		if err != nil {
 			return nil, Result{}, fmt.Errorf("edit failed: %w", err)
 		}
-		return nil, Result{Message: "Message edite avec succes."}, nil
+		return nil, Result{Message: fmt.Sprintf("Message édité sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
 	}
 }
 
@@ -259,10 +272,11 @@ func handleCreateTopic(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[C
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
 		}
-		if err := client.CreateTopic(input.Cat, input.Subcat, input.Subject, input.Content); err != nil {
+		id, err := client.CreateTopic(input.Cat, input.Subcat, input.Subject, input.Content, input.Expect)
+		if err != nil {
 			return nil, Result{}, fmt.Errorf("create topic failed: %w", err)
 		}
-		return nil, Result{Message: "Topic cree avec succes."}, nil
+		return nil, Result{Message: fmt.Sprintf("Topic créé sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
 	}
 }
 
@@ -271,9 +285,27 @@ func handleMP(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[MPInput, R
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
 		}
-		if err := client.SendMP(input.Dest, input.Subject, input.Content); err != nil {
+		id, err := client.SendMP(input.Dest, input.Subject, input.Content, input.Expect)
+		if err != nil {
 			return nil, Result{}, fmt.Errorf("mp failed: %w", err)
 		}
-		return nil, Result{Message: "MP envoye avec succes."}, nil
+		return nil, Result{Message: fmt.Sprintf("MP envoyé sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
+	}
+}
+
+func handleWhoami(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[WhoamiInput, Result] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input WhoamiInput) (*mcp.CallToolResult, Result, error) {
+		if err := login(); err != nil {
+			return nil, Result{}, fmt.Errorf("login failed: %w", err)
+		}
+		id, err := client.Whoami()
+		if err != nil {
+			return nil, Result{}, fmt.Errorf("whoami failed: %w", err)
+		}
+		expect := client.ExpectedLogin()
+		if expect == "" {
+			expect = "(non défini)"
+		}
+		return nil, Result{Message: fmt.Sprintf("Connecté : %s (userId %s). Compte attendu : %s.", id.Pseudo, id.UserID, expect)}, nil
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -306,6 +306,10 @@ func handleWhoami(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[Whoami
 		if expect == "" {
 			expect = "(non défini)"
 		}
-		return nil, Result{Message: fmt.Sprintf("Connecté : %s (userId %s). Compte attendu : %s.", id.Pseudo, id.UserID, expect)}, nil
+		guard := "inactive"
+		if client.GuardActive() {
+			guard = "active"
+		}
+		return nil, Result{Message: fmt.Sprintf("Connecté : %s (userId %s). Compte attendu : %s. Garde : %s.", id.Pseudo, id.UserID, expect, guard)}, nil
 	}
 }


### PR DESCRIPTION
## Summary
Guard against posting under the wrong HFR account (#32). Writes are refused when the logged-in account doesn't match the expected one — fail-closed by default.

## What's included
- Typed `Identity` + `identityMatches` (`pseudo:` / `id:`, bare numeric → userId)
- Fail-closed `checkIdentity`; server-side `HFR_EXPECT_LOGIN` + per-call `expect` (MCP) / `--pseudo` (CLI); opt-out `HFR_ALLOW_UNGUARDED_WRITES=1`
- Identity resolved at login (pseudo via `md_user` cookie = authority; userId best-effort) with state rollback on failure
- Atomic guarded write path (`authenticatedPost`): identity re-checked from the live cookie immediately before every POST (TOCTOU-safe, incl. Edit's GET→POST)
- `hfr_whoami` MCP tool / `hfr whoami` CLI; `expect` on write tools; `--pseudo` CLI flag
- Config + MCP + CLI wiring; README/AGENTS docs + CHANGELOG; bump to v1.2.0

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — 19 tests (identity matrix, login rollback + mismatch, userId from cookie/page/unresolved, guard-before-POST no-POST proof, Edit cookie-drift TOCTOU, config env)
- [ ] golangci-lint v2 (CI)
- [ ] Live verification: confirm `parseUserID` resolves the real userId against the live `editprofil` page (cookie `md_user_id` primary; HTML fallback selector to validate). Fail-safe: the pseudo guard holds regardless.

## Known follow-up
`parseUserID`'s HTML fallback selector is unverified against live markup. The cookie path is primary; an unresolved userId makes `id:` constraints error rather than silently pass.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)