### PR TITLE
fix: preserve email-notify subscription on reply (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@
 - `HFR_ALLOW_UNGUARDED_WRITES=1` opt-out for the historical (unguarded) behaviour.
 - New `hfr_whoami` MCP tool / `hfr whoami` CLI command: report the active account (pseudo + userId) and the expected account.
 - Write results now report the account effectively used.
+- Email-notify subscription control on reply (#31): `hfr_reply` preserves the topic's email-notification state instead of silently unsubscribing, and can change it — `notify` MCP parameter / `--notify on|off` CLI flag (empty = keep). Invalid values are rejected before posting. The reply result reports the effective subscription state.
 
 ### Fixes
 - Login hardening: client state is mutated only on full success — a failed `hash_check`/profile fetch no longer leaves a half-authenticated client.
+- `hfr_reply` no longer disables the topic's email notification when posting (#31).
+
+### Infrastructure
+- Dependency: `modelcontextprotocol/go-sdk` 1.4.1 → 1.6.1.
+- CI/Release workflows opt JS actions into Node 24 (Node 20 deprecated on GitHub runners from 2026-06-16).
 
 ## [1.1.0] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ hfr --auth read 13 120036 350
 # Poster une reponse (auth automatique)
 hfr reply 13 120036 "Hello HFR :o"
 
+# Poster en (dés)activant la notification e-mail du sujet (vide = conserver)
+hfr reply 13 120036 "Hello" --notify on
+hfr reply 13 120036 "Hello" --notify off
+
 # Citer (retourne le BBCode [quotemsg=...])
 hfr quote 13 120036 74497677
 
@@ -137,7 +141,7 @@ Les commandes d'ecriture (`new`, `reply`, `edit`, `mp`) et `quote`/`whoami` exig
 | `hfr_read` | Lire un topic. `page=0` pour la derniere page, `page_from`/`page_to` pour du batch concurrent, `print=true` pour le mode impression, `last=N` pour les N derniers posts |
 | `hfr_topics` | Lister les topics d'une categorie/sous-categorie avec pagination |
 | `hfr_cats` | Lister les categories (et les sous-categories d'une categorie) |
-| `hfr_reply` | Poster une reponse (BBCode). Param `expect` pour le garde-fou d'identite |
+| `hfr_reply` | Poster une reponse (BBCode). Param `expect` (garde-fou d'identite) ; param `notify` (`on`/`off`/vide) pour (dés)activer la notification e-mail du sujet, vide = conserver l'etat actuel |
 | `hfr_create_topic` | Creer un topic. Param `expect` pour le garde-fou d'identite |
 | `hfr_edit` | Editer un post existant (detecte le first post, preserve le sujet). Param `expect` |
 | `hfr_quote` | Citer un ou plusieurs messages (`numreponse` ou `numreponses[]`) |

--- a/cmd/hfr/main.go
+++ b/cmd/hfr/main.go
@@ -295,19 +295,19 @@ func cmdReply(client *hfr.Client, args []string, expect string) {
 	notify := hfr.NotifyKeep
 	filtered := args[:0:len(args)]
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--notify" && i+1 < len(args) {
-			switch args[i+1] {
-			case "on":
-				notify = hfr.NotifySubscribe
-			case "off":
-				notify = hfr.NotifyUnsubscribe
-			default:
-				die("--notify must be 'on' or 'off', got %q", args[i+1])
+		if args[i] == "--notify" {
+			if i+1 >= len(args) {
+				die("--notify requires a value: on or off")
 			}
+			m, err := hfr.ParseNotifyMode(args[i+1])
+			if err != nil {
+				die("%v", err)
+			}
+			notify = m
 			i++ // skip value
-		} else {
-			filtered = append(filtered, args[i])
+			continue
 		}
+		filtered = append(filtered, args[i])
 	}
 	args = filtered
 

--- a/cmd/hfr/main.go
+++ b/cmd/hfr/main.go
@@ -19,7 +19,7 @@ Commands:
   read     <cat> <post> [page|last|from:to] [-o file]  Read a topic
   print    <cat> <post> [page] [--last N] [-o file]  Read in print mode (~1000 posts/page)
   new      <cat> <subcat> <subject> <content|--file path>  Create a new topic
-  reply    <cat> <post> <content|--file path>             Post a reply
+  reply    <cat> <post> <content|--file path> [--notify on|off]  Post a reply
   edit     <cat> <post> <numreponse> <content|--file path>  Edit a post
   quote    <cat> <post> <numreponse>          Get quote BBCode
   mp       <dest> <subject> <content>         Send a private message
@@ -291,17 +291,45 @@ func cmdNewTopic(client *hfr.Client, args []string, expect string) {
 }
 
 func cmdReply(client *hfr.Client, args []string, expect string) {
+	// Parse optional --notify on|off flag before positional args.
+	notify := hfr.NotifyKeep
+	filtered := args[:0:len(args)]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--notify" && i+1 < len(args) {
+			switch args[i+1] {
+			case "on":
+				notify = hfr.NotifySubscribe
+			case "off":
+				notify = hfr.NotifyUnsubscribe
+			default:
+				die("--notify must be 'on' or 'off', got %q", args[i+1])
+			}
+			i++ // skip value
+		} else {
+			filtered = append(filtered, args[i])
+		}
+	}
+	args = filtered
+
 	if len(args) < 3 {
-		die("usage: hfr reply <cat> <post> <content|--file path>")
+		die("usage: hfr reply <cat> <post> <content|--file path> [--notify on|off]")
 	}
 	cat := mustInt(args[0], "cat")
 	post := mustInt(args[1], "post")
 	content := readContent(args[2:])
-	id, err := client.Reply(cat, post, content, expect)
+	res, err := client.Reply(cat, post, content, expect, notify)
 	if err != nil {
 		die("reply failed: %v", err)
 	}
-	fmt.Printf("Reply posted (as %s / userId %s).\n", id.Pseudo, id.UserID)
+	notifyStr := "unchanged"
+	if res.Subscribed != nil {
+		if *res.Subscribed {
+			notifyStr = "subscribed"
+		} else {
+			notifyStr = "unsubscribed"
+		}
+	}
+	fmt.Printf("Reply posted (as %s / userId %s). Email notify: %s.\n", res.Identity.Pseudo, res.Identity.UserID, notifyStr)
 }
 
 func cmdEdit(client *hfr.Client, args []string, expect string) {

--- a/internal/hfr/client.go
+++ b/internal/hfr/client.go
@@ -159,7 +159,15 @@ func (c *Client) currentIdentity() (Identity, error) {
 	if pseudo == "" {
 		return Identity{}, ErrNotAuthenticated
 	}
-	return Identity{Pseudo: pseudo, UserID: c.userID, Authenticated: true}, nil
+	// c.userID was resolved for c.pseudo at login and is never refreshed. If the
+	// live md_user cookie has drifted to another account, the cached userID is no
+	// longer trustworthy — drop it so `id:` constraints fail-closed (error: userId
+	// unresolved) instead of matching the stale id of a different session.
+	userID := c.userID
+	if !strings.EqualFold(pseudo, c.pseudo) {
+		userID = ""
+	}
+	return Identity{Pseudo: pseudo, UserID: userID, Authenticated: true}, nil
 }
 
 // Whoami returns the account currently behind the session.
@@ -252,6 +260,15 @@ func (c *Client) doGet(fullURL string) (*goquery.Document, error) {
 // only then POSTs. Returns the identity used. The identity check and the POST
 // are atomic; any pre-fetch GET (e.g. Edit's edit-page load) is intentionally
 // outside this lock — the guard still re-checks immediately before the POST.
+//
+// Concurrency assumption: the cookie jar is shared, and reads/pre-fetch GETs run
+// outside c.mu. The check+POST is only truly atomic against the jar if no other
+// goroutine mutates the session cookies in between. In practice this holds: login
+// runs once (sync.Once on the MCP server; single-threaded on the CLI) and HFR does
+// not re-issue md_user on read GETs, so the session identity is immutable for the
+// process lifetime — concurrent GETs cannot change who the POST authenticates as.
+// Closing this structurally (pinning the verified cookies onto the POST, or
+// serializing jar access) is tracked as follow-up hardening of the #32 guard.
 func (c *Client) authenticatedPost(endpoint string, data url.Values, expect, errCode string) (Identity, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/hfr/notify.go
+++ b/internal/hfr/notify.go
@@ -1,5 +1,7 @@
 package hfr
 
+import "fmt"
+
 // NotifyMode controls the email-notification subscription for a topic when
 // posting a reply. The default (NotifyKeep) preserves the current server-side
 // state by round-tripping the value from the reply form.
@@ -14,6 +16,23 @@ const (
 	// NotifyUnsubscribe forces email notifications off (emaill=0).
 	NotifyUnsubscribe
 )
+
+// ParseNotifyMode maps a user-facing value to a NotifyMode. Empty means keep.
+// It rejects any other value so an invalid input fails fast before a write,
+// rather than silently falling back to keep (a typo like "OFF" would otherwise
+// leave the subscription unchanged while the caller believed it changed).
+func ParseNotifyMode(s string) (NotifyMode, error) {
+	switch s {
+	case "":
+		return NotifyKeep, nil
+	case "on":
+		return NotifySubscribe, nil
+	case "off":
+		return NotifyUnsubscribe, nil
+	default:
+		return NotifyKeep, fmt.Errorf("invalid notify value %q (expected \"on\", \"off\", or empty)", s)
+	}
+}
 
 // ReplyResult holds the outcome of a successful Reply call.
 type ReplyResult struct {

--- a/internal/hfr/notify.go
+++ b/internal/hfr/notify.go
@@ -1,0 +1,27 @@
+package hfr
+
+// NotifyMode controls the email-notification subscription for a topic when
+// posting a reply. The default (NotifyKeep) preserves the current server-side
+// state by round-tripping the value from the reply form.
+type NotifyMode int
+
+const (
+	// NotifyKeep preserves the current email-notify subscription state.
+	// The value round-tripped from the reply form is used as-is.
+	NotifyKeep NotifyMode = iota
+	// NotifySubscribe forces email notifications on (emaill=1).
+	NotifySubscribe
+	// NotifyUnsubscribe forces email notifications off (emaill=0).
+	NotifyUnsubscribe
+)
+
+// ReplyResult holds the outcome of a successful Reply call.
+type ReplyResult struct {
+	// Identity is the account that posted the message, as verified by the
+	// fail-closed guard immediately before the POST.
+	Identity Identity
+	// Subscribed is the email-notification state in effect after the post.
+	// true = subscribed, false = unsubscribed, nil = state unknown (form fetch
+	// failed or emaill field was not found).
+	Subscribed *bool
+}

--- a/internal/hfr/notify_test.go
+++ b/internal/hfr/notify_test.go
@@ -1,0 +1,258 @@
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// parseDoc is a helper that parses an HTML string into a goquery document.
+func parseDoc(t *testing.T, html string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse HTML: %v", err)
+	}
+	return doc
+}
+
+// TestParseNotifyStateCheckboxChecked: checkbox emaill with checked attr → true.
+func TestParseNotifyStateCheckboxChecked(t *testing.T) {
+	doc := parseDoc(t, `<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input class="checkbox opt" type="checkbox" value="1" name="emaill" checked="checked" id="emaill" />
+<textarea name="content_form"></textarea>
+</form></body></html>`)
+	got := parseNotifyState(doc)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if !*got {
+		t.Fatalf("expected true (subscribed), got false")
+	}
+}
+
+// TestParseNotifyStateCheckboxUnchecked: checkbox emaill without checked → false.
+func TestParseNotifyStateCheckboxUnchecked(t *testing.T) {
+	doc := parseDoc(t, `<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input class="checkbox opt" type="checkbox" value="1" name="emaill" id="emaill" />
+<textarea name="content_form"></textarea>
+</form></body></html>`)
+	got := parseNotifyState(doc)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if *got {
+		t.Fatalf("expected false (not subscribed), got true")
+	}
+}
+
+// TestParseNotifyStateHiddenOne: hidden emaill value="1" → true.
+func TestParseNotifyStateHiddenOne(t *testing.T) {
+	doc := parseDoc(t, `<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="hidden" name="emaill" value="1" />
+<textarea name="content_form"></textarea>
+</form></body></html>`)
+	got := parseNotifyState(doc)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if !*got {
+		t.Fatalf("expected true (hidden value=1), got false")
+	}
+}
+
+// TestParseNotifyStateHiddenZero: hidden emaill value="0" → false.
+func TestParseNotifyStateHiddenZero(t *testing.T) {
+	doc := parseDoc(t, `<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="hidden" name="emaill" value="0" />
+<textarea name="content_form"></textarea>
+</form></body></html>`)
+	got := parseNotifyState(doc)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if *got {
+		t.Fatalf("expected false (hidden value=0), got true")
+	}
+}
+
+// TestParseNotifyStateAbsent: no emaill field → nil.
+func TestParseNotifyStateAbsent(t *testing.T) {
+	doc := parseDoc(t, `<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="hidden" name="other_field" value="42" />
+<textarea name="content_form"></textarea>
+</form></body></html>`)
+	got := parseNotifyState(doc)
+	if got != nil {
+		t.Fatalf("expected nil (field absent), got %v", *got)
+	}
+}
+
+// notifyModeServer builds a test server where message.php serves the given
+// emaill HTML snippet, and bddpost.php captures the POST body.
+func notifyModeServer(t *testing.T, emailllHTML string, gotPost *url.Values, postCount *int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+` + emailllHTML + `
+<textarea name="content_form"></textarea>
+</form></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(postCount, 1)
+		_ = r.ParseForm()
+		*gotPost = r.PostForm
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestReplyNotifyKeepChecked: NotifyKeep + checked emaill checkbox → POST carries emaill=1.
+func TestReplyNotifyKeepChecked(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	// message.php renders checked emaill checkbox (subscribed).
+	srv := notifyModeServer(t,
+		`<input type="checkbox" value="1" name="emaill" checked="checked" id="emaill" />`,
+		&gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	res, err := c.Reply(23, 35421, "hello", "id:1214571", NotifyKeep)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST, got %d", postCount)
+	}
+	// Checked checkbox is preserved → emaill=1 in POST.
+	if got := gotPost.Get("emaill"); got != "1" {
+		t.Fatalf("NotifyKeep+checked: emaill=%q in POST, want 1", got)
+	}
+	// ReplyResult.Subscribed == true (state from form).
+	if res.Subscribed == nil || !*res.Subscribed {
+		t.Fatalf("NotifyKeep+checked: Subscribed=%v, want true", res.Subscribed)
+	}
+}
+
+// TestReplyNotifyKeepUnchecked: NotifyKeep + unchecked emaill → POST has NO emaill field.
+func TestReplyNotifyKeepUnchecked(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	// message.php renders unchecked emaill checkbox (not subscribed).
+	srv := notifyModeServer(t,
+		`<input type="checkbox" value="1" name="emaill" id="emaill" />`,
+		&gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	res, err := c.Reply(23, 35421, "hello", "id:1214571", NotifyKeep)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST, got %d", postCount)
+	}
+	// Unchecked checkbox is not submitted by browser semantics → no emaill in POST.
+	if _, present := gotPost["emaill"]; present {
+		t.Fatalf("NotifyKeep+unchecked: emaill must not be in POST, got %v", gotPost["emaill"])
+	}
+	// ReplyResult.Subscribed == false (state from form).
+	if res.Subscribed == nil || *res.Subscribed {
+		t.Fatalf("NotifyKeep+unchecked: Subscribed=%v, want false", res.Subscribed)
+	}
+}
+
+// TestReplyNotifySubscribe: NotifySubscribe + unchecked emaill → POST carries emaill=1;
+// ReplyResult.Subscribed == true.
+func TestReplyNotifySubscribe(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	// message.php renders UNCHECKED emaill — the mode must override it.
+	srv := notifyModeServer(t,
+		`<input type="checkbox" value="1" name="emaill" id="emaill" />`,
+		&gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	res, err := c.Reply(23, 35421, "hello", "id:1214571", NotifySubscribe)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST, got %d", postCount)
+	}
+	// NotifySubscribe forces emaill=1 regardless of form state.
+	if got := gotPost.Get("emaill"); got != "1" {
+		t.Fatalf("NotifySubscribe: emaill=%q in POST, want 1", got)
+	}
+	// ReplyResult.Subscribed == true.
+	if res.Subscribed == nil || !*res.Subscribed {
+		t.Fatalf("NotifySubscribe: Subscribed=%v, want true", res.Subscribed)
+	}
+}
+
+// TestReplyNotifyUnsubscribe: NotifyUnsubscribe + checked emaill → POST carries emaill=0;
+// ReplyResult.Subscribed == false.
+func TestReplyNotifyUnsubscribe(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	// message.php renders CHECKED emaill — the mode must override it.
+	srv := notifyModeServer(t,
+		`<input type="checkbox" value="1" name="emaill" checked="checked" id="emaill" />`,
+		&gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	res, err := c.Reply(23, 35421, "hello", "id:1214571", NotifyUnsubscribe)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST, got %d", postCount)
+	}
+	// NotifyUnsubscribe forces emaill=0 regardless of form state.
+	if got := gotPost.Get("emaill"); got != "0" {
+		t.Fatalf("NotifyUnsubscribe: emaill=%q in POST, want 0", got)
+	}
+	// ReplyResult.Subscribed == false.
+	if res.Subscribed == nil || *res.Subscribed {
+		t.Fatalf("NotifyUnsubscribe: Subscribed=%v, want false", res.Subscribed)
+	}
+}

--- a/internal/hfr/notify_test.go
+++ b/internal/hfr/notify_test.go
@@ -256,3 +256,28 @@ func TestReplyNotifyUnsubscribe(t *testing.T) {
 		t.Fatalf("NotifyUnsubscribe: Subscribed=%v, want false", res.Subscribed)
 	}
 }
+
+func TestParseNotifyMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    NotifyMode
+		wantErr bool
+	}{
+		{"", NotifyKeep, false},
+		{"on", NotifySubscribe, false},
+		{"off", NotifyUnsubscribe, false},
+		{"OFF", NotifyKeep, true},
+		{"true", NotifyKeep, true},
+		{"1", NotifyKeep, true},
+		{"keep", NotifyKeep, true},
+	}
+	for _, tc := range cases {
+		got, err := ParseNotifyMode(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("ParseNotifyMode(%q) err=%v, wantErr=%v", tc.in, err, tc.wantErr)
+		}
+		if !tc.wantErr && got != tc.want {
+			t.Fatalf("ParseNotifyMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/hfr/parser.go
+++ b/internal/hfr/parser.go
@@ -80,6 +80,47 @@ func preserveReplyFormFields(doc *goquery.Document) url.Values {
 	return out
 }
 
+// parseNotifyState reads the email-notification subscription state from the
+// reply form in doc. It understands two representations used by HFR:
+//
+//   - checkbox `emaill` (on message.php reply form): checked = subscribed,
+//     absent checked attr = not subscribed.
+//   - hidden input `emaill` (forum2.php quick-reply): value "1" = subscribed,
+//     "0" = not subscribed.
+//
+// Returns a pointer to true/false, or nil if the field is not found.
+func parseNotifyState(doc *goquery.Document) *bool {
+	// Locate the reply form (same logic as preserveReplyFormFields).
+	form := doc.Find(`form[action*="bddpost.php"]`).First()
+	if form.Length() == 0 {
+		form = doc.Find("form").FilterFunction(func(_ int, s *goquery.Selection) bool {
+			return s.Find("textarea[name=content_form]").Length() > 0
+		}).First()
+	}
+	if form.Length() == 0 {
+		return nil
+	}
+
+	var result *bool
+	form.Find(`input[name="emaill"]`).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		typ, _ := s.Attr("type")
+		switch strings.ToLower(typ) {
+		case "checkbox":
+			_, checked := s.Attr("checked")
+			v := checked
+			result = &v
+			return false // stop
+		case "hidden", "":
+			val, _ := s.Attr("value")
+			v := val == "1"
+			result = &v
+			return false // stop
+		}
+		return true
+	})
+	return result
+}
+
 // parseEditPage extracts FP detection and subcat/subject from an edit page
 func parseEditPage(doc *goquery.Document) EditInfo {
 	info := EditInfo{}

--- a/internal/hfr/parser.go
+++ b/internal/hfr/parser.go
@@ -1,6 +1,7 @@
 package hfr
 
 import (
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +14,71 @@ var (
 	reMessageCited  = regexp.MustCompile(`Message cité \d+ fois?`)
 	reSignature     = regexp.MustCompile(`(?m)\s*-{15}\n\t\t\t.*$`)
 )
+
+// preserveReplyFormFields extracts the server-rendered form state from the
+// reply page so a POST approximates what a browser would send. It returns every
+// named field of the reply form (the one whose action targets bddpost.php),
+// EXCEPT the message body (content_form) and submit/button controls. Checkboxes
+// and radios are included only when the page rendered them checked — this is how
+// the email-notify subscription is carried: HFR renders the notify checkbox
+// "checked" iff the user is currently subscribed, so preserving it verbatim
+// keeps the subscription untouched (bug #31). The field name is intentionally
+// not hardcoded; whatever HFR names it, a checked checkbox round-trips.
+//
+// Not a full browser emulation: <select> only emits an explicitly selected
+// <option> (no "first option when none selected" fallback, no option-text when
+// value is absent). That is sufficient here — the reply form's selects do not
+// carry subscription state — but is why this is "approximates", not "mirrors".
+func preserveReplyFormFields(doc *goquery.Document) url.Values {
+	out := url.Values{}
+	form := doc.Find(`form[action*="bddpost.php"]`).First()
+	if form.Length() == 0 {
+		// Fall back to any form carrying the content_form textarea.
+		form = doc.Find("form").FilterFunction(func(_ int, s *goquery.Selection) bool {
+			return s.Find("textarea[name=content_form]").Length() > 0
+		}).First()
+	}
+	if form.Length() == 0 {
+		return out
+	}
+	form.Find("input").Each(func(_ int, s *goquery.Selection) {
+		name, ok := s.Attr("name")
+		if !ok || name == "" || name == "content_form" {
+			return
+		}
+		typ, _ := s.Attr("type")
+		switch strings.ToLower(typ) {
+		case "submit", "button", "image", "reset", "file", "password":
+			return
+		case "checkbox", "radio":
+			if _, checked := s.Attr("checked"); !checked {
+				return // unchecked controls are not submitted by a browser
+			}
+			val, has := s.Attr("value")
+			if !has || val == "" {
+				val = "on" // browser default for a valueless checked box
+			}
+			out.Add(name, val)
+			return
+		}
+		val, _ := s.Attr("value")
+		out.Set(name, val)
+	})
+	// select: take the selected <option> value of each named select.
+	form.Find("select[name]").Each(func(_ int, sel *goquery.Selection) {
+		name, _ := sel.Attr("name")
+		if name == "" {
+			return
+		}
+		opt := sel.Find("option[selected]").First()
+		if opt.Length() == 0 {
+			return
+		}
+		val, _ := opt.Attr("value")
+		out.Set(name, val)
+	})
+	return out
+}
 
 // parseEditPage extracts FP detection and subcat/subject from an edit page
 func parseEditPage(doc *goquery.Document) EditInfo {

--- a/internal/hfr/post.go
+++ b/internal/hfr/post.go
@@ -16,16 +16,26 @@ import (
 // md_user cookie and re-checks identity immediately before the POST, so the
 // fail-closed #32 guard still gates the actual write.
 //
+// notify controls the email-notification subscription:
+//   - NotifyKeep (default): preserves the current subscription from the form.
+//   - NotifySubscribe: forces emaill=1 regardless of current state.
+//   - NotifyUnsubscribe: forces emaill=0 regardless of current state.
+//
+// The returned ReplyResult carries the Identity verified by the guard and the
+// effective Subscribed state after the post (nil when unknown).
+//
 // Side effect: this authenticated GET on message.php likely marks the topic as
 // read (HFR's "lu" flag), even if the POST is subsequently refused by the guard.
 // This is benign — opening the reply form in a browser does the same, and an
 // agent replying has typically just read the topic.
-func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error) {
+func (c *Client) Reply(cat, postId int, content, expect string, notify NotifyMode) (ReplyResult, error) {
 	replyURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&page=0&p=1&new=0",
 		c.baseURL, cat, postId)
 	preserved := url.Values{}
+	var state *bool
 	if replyDoc, err := c.doGet(replyURL); err == nil {
 		preserved = preserveReplyFormFields(replyDoc)
+		state = parseNotifyState(replyDoc)
 	}
 	// If the form fetch fails we fall back to the legacy hardcoded fields rather
 	// than block the reply; the notify field is then simply omitted as before.
@@ -49,7 +59,26 @@ func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error
 	// subscription state we must round-trip.
 	mergePreservedFields(data, preserved)
 
-	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "post")
+	// Apply the notify mode AFTER merge so it wins over the preserved value.
+	var effective *bool
+	switch notify {
+	case NotifySubscribe:
+		data.Set("emaill", "1")
+		v := true
+		effective = &v
+	case NotifyUnsubscribe:
+		data.Set("emaill", "0")
+		v := false
+		effective = &v
+	default: // NotifyKeep
+		effective = state
+	}
+
+	id, err := c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "post")
+	if err != nil {
+		return ReplyResult{}, err
+	}
+	return ReplyResult{Identity: id, Subscribed: effective}, nil
 }
 
 // mergePreservedFields copies fields from the server-rendered reply form into

--- a/internal/hfr/post.go
+++ b/internal/hfr/post.go
@@ -2,11 +2,34 @@ package hfr
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 )
 
-// Reply posts a new message on a topic
+// Reply posts a new message on a topic.
+//
+// It first GETs the reply form (message.php, like the quote/edit pages) and
+// preserves the server-rendered form state — most importantly the email-notify
+// checkbox — so the POST mirrors a browser and does not silently unsubscribe the
+// user from the topic's email notifications (bug #31). The GET runs BEFORE
+// authenticatedPost, exactly like Edit: authenticatedPost re-reads the live
+// md_user cookie and re-checks identity immediately before the POST, so the
+// fail-closed #32 guard still gates the actual write.
+//
+// Side effect: this authenticated GET on message.php likely marks the topic as
+// read (HFR's "lu" flag), even if the POST is subsequently refused by the guard.
+// This is benign — opening the reply form in a browser does the same, and an
+// agent replying has typically just read the topic.
 func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error) {
+	replyURL := fmt.Sprintf("%s/message.php?config=hfr.inc&cat=%d&post=%d&page=0&p=1&new=0",
+		c.baseURL, cat, postId)
+	preserved := url.Values{}
+	if replyDoc, err := c.doGet(replyURL); err == nil {
+		preserved = preserveReplyFormFields(replyDoc)
+	}
+	// If the form fetch fails we fall back to the legacy hardcoded fields rather
+	// than block the reply; the notify field is then simply omitted as before.
+
 	data := c.baseFormData(strconv.Itoa(cat), content)
 	data.Set("post", strconv.Itoa(postId))
 	data.Set("sujet", c.pseudo)
@@ -18,7 +41,42 @@ func (c *Client) Reply(cat, postId int, content, expect string) (Identity, error
 	data.Set("cache", "")
 	data.Set("search_smilies", "")
 	data.Set("ColorUsedMem", "")
+
+	// Merge preserved server state. Fields we deliberately control above
+	// (content_form, identity, sujet, …) are already set and must win, so we only
+	// add preserved fields we have not set ourselves — except the notify-style
+	// checked controls, which the base form never sets and which carry the
+	// subscription state we must round-trip.
+	mergePreservedFields(data, preserved)
+
 	return c.authenticatedPost("/bddpost.php?config=hfr.inc", data, expect, "post")
+}
+
+// mergePreservedFields copies fields from the server-rendered reply form into
+// the outgoing POST without clobbering fields the client deliberately set.
+// content_form is never copied (the body is ours). hash_check is never copied:
+// the login-time anti-CSRF token in baseFormData is authoritative for the POST.
+//
+// Deliberately conservative (vs a form-wins allowlist): the client's hardcoded
+// fields (signature, sondage, owntopic, …) keep their legacy values rather than
+// being round-tripped from the server form. This preserves the pre-#31 behavior
+// for those fields (no regression) and limits this change to *adding* the
+// subscription/notify state the base form omits — at the cost of not mirroring a
+// server-set value on a field we already control. Revisit per-field only if a
+// concrete setting is shown to be wrongly overridden.
+func mergePreservedFields(data, preserved url.Values) {
+	for name, vals := range preserved {
+		if name == "content_form" || name == "hash_check" {
+			continue
+		}
+		if _, set := data[name]; set {
+			// We already control this field (e.g. cat, post, sujet); keep ours.
+			continue
+		}
+		for _, v := range vals {
+			data.Add(name, v)
+		}
+	}
 }
 
 // CreateTopic creates a new topic in a category

--- a/internal/hfr/reply_notif_test.go
+++ b/internal/hfr/reply_notif_test.go
@@ -1,0 +1,342 @@
+package hfr
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+)
+
+// replyNotifyServer logs in, serves a reply form on message.php that carries a
+// CHECKED email-notify checkbox plus a few hidden state fields, and captures the
+// body of the bddpost.php POST so the test can assert the notify field was
+// round-tripped (bug #31). It also renders an UNCHECKED extra checkbox and a
+// server hash_check that must NOT override the login-time token.
+func replyNotifyServer(t *testing.T, pseudo, userID, notifyName, notifyVal string, gotPost *url.Values, postCount *int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: pseudo, Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: userID, Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// A representative reply form. The notify checkbox is rendered checked,
+		// meaning the user is currently subscribed; preserving it keeps the sub.
+		_, _ = w.Write([]byte(`<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post" name="repondre">
+<input type="hidden" name="hash_check" value="SERVERHASH">
+<input type="hidden" name="cat" value="23">
+<input type="hidden" name="post" value="35421">
+<input type="hidden" name="stickold" value="99">
+<input type="checkbox" name="` + notifyName + `" value="` + notifyVal + `" checked>
+<input type="checkbox" name="some_other_opt" value="7">
+<textarea name="content_form"></textarea>
+<input type="submit" name="submit" value="Valider votre message">
+</form>
+</body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(postCount, 1)
+		_ = r.ParseForm()
+		*gotPost = r.PostForm
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	return httptest.NewServer(mux)
+}
+
+// Bug #31: a reply must carry the email-notify field that the reply form
+// rendered as checked, so HFR keeps the user subscribed.
+func TestReplyPreservesNotifyField(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	srv := replyNotifyServer(t, "xatelitte", "1214571", "notif", "1", &gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	id, err := c.Reply(23, 35421, "hello", "id:1214571")
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if id.Pseudo != "xatelitte" {
+		t.Fatalf("identity = %+v", id)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected exactly one POST, got %d", postCount)
+	}
+
+	// The notify checkbox was checked on the form -> it must be in the POST.
+	if got := gotPost.Get("notif"); got != "1" {
+		t.Fatalf("notify field missing/wrong in POST: notif=%q, full=%v", got, gotPost)
+	}
+	// An unchecked checkbox must NOT be sent (browser semantics).
+	if _, present := gotPost["some_other_opt"]; present {
+		t.Fatalf("unchecked checkbox must not be submitted, got %v", gotPost)
+	}
+	// The body is the client's, never the form's empty textarea.
+	if got := gotPost.Get("content_form"); got != "hello" {
+		t.Fatalf("content_form = %q, want %q", got, "hello")
+	}
+	// stickold is a field the base form deliberately controls (set to ""), so the
+	// client value wins over the form's — preserved fields never clobber ours.
+	if got := gotPost.Get("stickold"); got != "" {
+		t.Fatalf("stickold = %q, want client-controlled empty value", got)
+	}
+	// hash_check must remain the login-time token, NOT the form's value.
+	if got := gotPost.Get("hash_check"); got != "LOGINHASH" {
+		t.Fatalf("hash_check = %q, want login token LOGINHASH (server form value must not override)", got)
+	}
+	// Client-controlled fields keep the client's value, not the form's.
+	if got := gotPost.Get("post"); got != "35421" {
+		t.Fatalf("post = %q, want 35421", got)
+	}
+}
+
+// The notify field name is not hardcoded: whatever HFR calls the checked
+// checkbox, it round-trips. This exercises the same path with a different name.
+func TestReplyPreservesNotifyFieldUnderDifferentName(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	srv := replyNotifyServer(t, "xatelitte", "1214571", "mail_notif", "yes", &gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetAllowUnguarded(true)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if got := gotPost.Get("mail_notif"); got != "yes" {
+		t.Fatalf("notify field (alt name) missing in POST: %v", gotPost)
+	}
+}
+
+// Guard interaction (#32): on an identity mismatch the reply form GET may run,
+// but authenticatedPost must still refuse the POST. No bddpost.php call happens.
+func TestReplyPreserveStillGuarded(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	srv := replyNotifyServer(t, "XaTriX", "54596", "notif", "1", &gotPost, &postCount)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("XaTriX", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if _, err := c.Reply(23, 35421, "hi", ""); err == nil {
+		t.Fatal("expected identity refusal")
+	}
+	if atomic.LoadInt32(&postCount) != 0 {
+		t.Fatalf("POST must not be sent on mismatch, got %d", postCount)
+	}
+}
+
+// Reinforcement test 1: TOCTOU cookie drift during the reply-form GET.
+// The md_user cookie switches to XaTriX while the GET for message.php is
+// served. authenticatedPost re-reads the live cookie before the POST and must
+// refuse it. No bddpost.php call must be made.
+func TestReplyPreserveCookieDriftBlocked(t *testing.T) {
+	var postCount int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		// Log in as xatelitte.
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// Session drifts: md_user flips to XaTriX while serving the reply form GET.
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "XaTriX", Path: "/"})
+		_, _ = w.Write([]byte(`<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="checkbox" name="notif" value="1" checked>
+<textarea name="content_form"></textarea>
+</form></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&postCount, 1)
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("xatelitte")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	// After GET, cookie is XaTriX; guard re-checks before POST → must refuse.
+	_, err := c.Reply(23, 35421, "hi", "")
+	if err == nil {
+		t.Fatal("expected identity refusal after cookie drift during form GET")
+	}
+	if atomic.LoadInt32(&postCount) != 0 {
+		t.Fatalf("POST must not be sent after cookie drift, got %d", atomic.LoadInt32(&postCount))
+	}
+}
+
+// Reinforcement test 1b: same TOCTOU drift but the guard is an id: constraint.
+// The cached userID (1214571, from the xatelitte login) would still satisfy
+// id:1214571 after the cookie drifts to another pseudo — unless currentIdentity
+// invalidates it on pseudo drift. The POST must be refused, no bddpost.php call.
+func TestReplyCookieDriftBlockedIdConstraint(t *testing.T) {
+	var postCount int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// Drift to another account (different pseudo) during the form GET.
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "XaTriX", Path: "/"})
+		_, _ = w.Write([]byte(`<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="checkbox" name="notif" value="1" checked>
+<textarea name="content_form"></textarea>
+</form></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&postCount, 1)
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetExpectedLogin("id:1214571")
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_, err := c.Reply(23, 35421, "hi", "")
+	if err == nil {
+		t.Fatal("expected refusal: stale userID must not satisfy id: after pseudo drift")
+	}
+	if atomic.LoadInt32(&postCount) != 0 {
+		t.Fatalf("POST must not be sent after drift, got %d", atomic.LoadInt32(&postCount))
+	}
+}
+
+// Reinforcement test 2: if the reply-form GET fails or returns junk (no form),
+// Reply must still POST (legacy fallback) rather than error out.
+func TestReplyFallsBackWhenFormGetFails(t *testing.T) {
+	var postCount int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// Return junk HTML with no reply form — preserveReplyFormFields returns empty.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><body><p>Nothing here</p></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&postCount, 1)
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetAllowUnguarded(true)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+		t.Fatalf("reply must succeed despite junk form GET: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST despite bad form GET, got %d", atomic.LoadInt32(&postCount))
+	}
+}
+
+// Reinforcement test 3: client-controlled fields win over preserved form values.
+// The reply form returns conflicting values for cat, sujet, and post; the POST
+// must carry the client's values, not the form's.
+func TestReplyClientFieldsWinOverPreserved(t *testing.T) {
+	var gotPost url.Values
+	var postCount int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login_validation.php", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "md_user", Value: "xatelitte", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "md_user_id", Value: "1214571", Path: "/"})
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/user/editprofil.php", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<input type="hidden" name="hash_check" value="LOGINHASH">`))
+	})
+	mux.HandleFunc("/message.php", func(w http.ResponseWriter, r *http.Request) {
+		// Form tries to inject conflicting values for client-controlled fields.
+		_, _ = w.Write([]byte(`<html><body>
+<form action="/bddpost.php?config=hfr.inc" method="post">
+<input type="hidden" name="hash_check" value="BADTOKEN">
+<input type="hidden" name="cat" value="999">
+<input type="hidden" name="post" value="00000">
+<input type="hidden" name="sujet" value="INJECTED_SUBJECT">
+<input type="checkbox" name="notif" value="1" checked>
+<textarea name="content_form"></textarea>
+</form></body></html>`))
+	})
+	mux.HandleFunc("/bddpost.php", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&postCount, 1)
+		_ = r.ParseForm()
+		gotPost = r.PostForm
+		_, _ = w.Write([]byte("Votre message a été posté avec succès"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.SetAllowUnguarded(true)
+	if err := c.Login("xatelitte", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("expected one POST, got %d", atomic.LoadInt32(&postCount))
+	}
+
+	// cat, post, sujet: client values must win.
+	if got := gotPost.Get("cat"); got != "23" {
+		t.Fatalf("cat = %q, want client value 23 (not form's 999)", got)
+	}
+	if got := gotPost.Get("post"); got != "35421" {
+		t.Fatalf("post = %q, want client value 35421 (not form's 00000)", got)
+	}
+	if got := gotPost.Get("sujet"); got != "xatelitte" {
+		t.Fatalf("sujet = %q, want pseudo xatelitte (not form's INJECTED_SUBJECT)", got)
+	}
+	// hash_check: login-time token must win, not BADTOKEN from form.
+	if got := gotPost.Get("hash_check"); got != "LOGINHASH" {
+		t.Fatalf("hash_check = %q, want LOGINHASH (not form's BADTOKEN)", got)
+	}
+	// The notify checkbox (not a client-set field) must still be preserved.
+	if got := gotPost.Get("notif"); got != "1" {
+		t.Fatalf("notif = %q, want 1 (should still be preserved)", got)
+	}
+}

--- a/internal/hfr/reply_notif_test.go
+++ b/internal/hfr/reply_notif_test.go
@@ -63,12 +63,12 @@ func TestReplyPreservesNotifyField(t *testing.T) {
 		t.Fatalf("login: %v", err)
 	}
 
-	id, err := c.Reply(23, 35421, "hello", "id:1214571")
+	res, err := c.Reply(23, 35421, "hello", "id:1214571", NotifyKeep)
 	if err != nil {
 		t.Fatalf("reply: %v", err)
 	}
-	if id.Pseudo != "xatelitte" {
-		t.Fatalf("identity = %+v", id)
+	if res.Identity.Pseudo != "xatelitte" {
+		t.Fatalf("identity = %+v", res.Identity)
 	}
 	if atomic.LoadInt32(&postCount) != 1 {
 		t.Fatalf("expected exactly one POST, got %d", postCount)
@@ -114,7 +114,7 @@ func TestReplyPreservesNotifyFieldUnderDifferentName(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+	if _, err := c.Reply(23, 35421, "hello", "", NotifyKeep); err != nil {
 		t.Fatalf("reply: %v", err)
 	}
 	if got := gotPost.Get("mail_notif"); got != "yes" {
@@ -135,7 +135,7 @@ func TestReplyPreserveStillGuarded(t *testing.T) {
 	if err := c.Login("XaTriX", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	if _, err := c.Reply(23, 35421, "hi", ""); err == nil {
+	if _, err := c.Reply(23, 35421, "hi", "", NotifyKeep); err == nil {
 		t.Fatal("expected identity refusal")
 	}
 	if atomic.LoadInt32(&postCount) != 0 {
@@ -181,7 +181,7 @@ func TestReplyPreserveCookieDriftBlocked(t *testing.T) {
 		t.Fatalf("login: %v", err)
 	}
 	// After GET, cookie is XaTriX; guard re-checks before POST → must refuse.
-	_, err := c.Reply(23, 35421, "hi", "")
+	_, err := c.Reply(23, 35421, "hi", "", NotifyKeep)
 	if err == nil {
 		t.Fatal("expected identity refusal after cookie drift during form GET")
 	}
@@ -226,7 +226,7 @@ func TestReplyCookieDriftBlockedIdConstraint(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	_, err := c.Reply(23, 35421, "hi", "")
+	_, err := c.Reply(23, 35421, "hi", "", NotifyKeep)
 	if err == nil {
 		t.Fatal("expected refusal: stale userID must not satisfy id: after pseudo drift")
 	}
@@ -265,7 +265,7 @@ func TestReplyFallsBackWhenFormGetFails(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+	if _, err := c.Reply(23, 35421, "hello", "", NotifyKeep); err != nil {
 		t.Fatalf("reply must succeed despite junk form GET: %v", err)
 	}
 	if atomic.LoadInt32(&postCount) != 1 {
@@ -314,7 +314,7 @@ func TestReplyClientFieldsWinOverPreserved(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	if _, err := c.Reply(23, 35421, "hello", ""); err != nil {
+	if _, err := c.Reply(23, 35421, "hello", "", NotifyKeep); err != nil {
 		t.Fatalf("reply: %v", err)
 	}
 	if atomic.LoadInt32(&postCount) != 1 {

--- a/internal/hfr/write_guard_test.go
+++ b/internal/hfr/write_guard_test.go
@@ -44,7 +44,7 @@ func TestReplyRefusedOnMismatchNoPost(t *testing.T) {
 	if err := c.Login("XaTriX", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	_, err := c.Reply(23, 35421, "hi", "")
+	_, err := c.Reply(23, 35421, "hi", "", NotifyKeep)
 	if err == nil {
 		t.Fatal("expected identity refusal")
 	}
@@ -62,12 +62,12 @@ func TestReplyAllowedReturnsIdentity(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	id, err := c.Reply(23, 35421, "hi", "id:1214571")
+	res, err := c.Reply(23, 35421, "hi", "id:1214571", NotifyKeep)
 	if err != nil {
 		t.Fatalf("reply: %v", err)
 	}
-	if id.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
-		t.Fatalf("id=%+v posted=%d", id, atomic.LoadInt32(&posted))
+	if res.Identity.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
+		t.Fatalf("id=%+v posted=%d", res.Identity, atomic.LoadInt32(&posted))
 	}
 }
 
@@ -140,11 +140,11 @@ func TestReplyAllowedWhenUnguarded(t *testing.T) {
 	if err := c.Login("xatelitte", "pw"); err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	id, err := c.Reply(23, 35421, "hi", "")
+	res, err := c.Reply(23, 35421, "hi", "", NotifyKeep)
 	if err != nil {
 		t.Fatalf("reply: %v", err)
 	}
-	if id.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
-		t.Fatalf("id=%+v posted=%d", id, atomic.LoadInt32(&posted))
+	if res.Identity.Pseudo != "xatelitte" || atomic.LoadInt32(&posted) != 1 {
+		t.Fatalf("id=%+v posted=%d", res.Identity, atomic.LoadInt32(&posted))
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -27,6 +27,7 @@ type ReplyInput struct {
 	Post    int    `json:"post" jsonschema:"Numero du topic"`
 	Content string `json:"content" jsonschema:"Contenu du message en BBCode HFR"`
 	Expect  string `json:"expect,omitempty" jsonschema:"Compte attendu (pseudo, id:NNNN, ou pseudo:nom) ; l'écriture est refusée si la session ne correspond pas"`
+	Notify  string `json:"notify,omitempty" jsonschema:"Notifications e-mail du sujet: 'on' pour s'abonner, 'off' pour se désabonner, vide pour conserver l'état actuel"`
 }
 
 type EditInput struct {
@@ -171,11 +172,28 @@ func handleReply(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReplyIn
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
 		}
-		id, err := client.Reply(input.Cat, input.Post, input.Content, input.Expect)
+		var notify hfr.NotifyMode
+		switch input.Notify {
+		case "on":
+			notify = hfr.NotifySubscribe
+		case "off":
+			notify = hfr.NotifyUnsubscribe
+		default:
+			notify = hfr.NotifyKeep
+		}
+		res, err := client.Reply(input.Cat, input.Post, input.Content, input.Expect, notify)
 		if err != nil {
 			return nil, Result{}, fmt.Errorf("reply failed: %w", err)
 		}
-		return nil, Result{Message: fmt.Sprintf("Message posté sous %s (userId %s).", id.Pseudo, id.UserID)}, nil
+		notifyStr := "inchangées"
+		if res.Subscribed != nil {
+			if *res.Subscribed {
+				notifyStr = "activées"
+			} else {
+				notifyStr = "désactivées"
+			}
+		}
+		return nil, Result{Message: fmt.Sprintf("Message posté sous %s (userId %s). Notifications e-mail : %s.", res.Identity.Pseudo, res.Identity.UserID, notifyStr)}, nil
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -169,17 +169,14 @@ func handleRead(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReadInpu
 
 func handleReply(client *hfr.Client, login LoginFunc) mcp.ToolHandlerFor[ReplyInput, Result] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ReplyInput) (*mcp.CallToolResult, Result, error) {
+		// Validate notify before logging in or posting: an invalid value must
+		// fail fast rather than silently keep the current subscription.
+		notify, err := hfr.ParseNotifyMode(input.Notify)
+		if err != nil {
+			return nil, Result{}, err
+		}
 		if err := login(); err != nil {
 			return nil, Result{}, fmt.Errorf("login failed: %w", err)
-		}
-		var notify hfr.NotifyMode
-		switch input.Notify {
-		case "on":
-			notify = hfr.NotifySubscribe
-		case "off":
-			notify = hfr.NotifyUnsubscribe
-		default:
-			notify = hfr.NotifyKeep
 		}
 		res, err := client.Reply(input.Cat, input.Post, input.Content, input.Expect, notify)
 		if err != nil {


### PR DESCRIPTION
## Summary
Fix #31: `hfr_reply` no longer silently unsubscribes the user from a topic's email notifications.

## What changed
- **Reply** GETs the reply form (`message.php`) before posting and **preserves the server-rendered checked fields** (notably the email-notify checkbox) into the POST, like a browser. The field name is **not hardcoded** — any checked checkbox round-trips. The form GET stays **before** `authenticatedPost`, so the #32 fail-closed guard still re-checks identity immediately before the POST.
- **Hardens the #32 guard (single-call TOCTOU on `id:`)**: `currentIdentity` now drops the cached `userID` when the live `md_user` pseudo no longer matches the login pseudo, so a stale `userID` can no longer satisfy an `id:` constraint after a drift.
- Conservative merge: client-set fields win over the form (no regression vs pre-#31); documented.

## Tests
`go build/vet` clean, `go test -race ./...` green. New tests: notify preservation (incl. name-agnostic), guard still enforced through Reply, cookie-drift refusal for **pseudo and `id:`** constraints, GET-failure fallback (legacy, no crash), client-fields-win.

## Review
- Workflow adversarial review: **SOUND**.
- Codex gpt-5.5 (xhigh), two passes: single-call TOCTOU **closed**; `id:` constraints intact; merge approved.

## Out of scope / follow-up
- **Concurrency hardening of the #32 guard vs the shared cookie jar** (theoretical inter-call race; infeasible in practice — login is once and HFR doesn't mutate `md_user` on read GETs): tracked in #36.
- **Live form capture** to confirm the exact notify field name — the fix is name-agnostic and falls back to legacy behavior if no form is found.

Closes #31 _(note: base is `dev`; default branch is `master`, so this won't auto-close — close manually at merge / on `dev`→`master`)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)